### PR TITLE
[codex] Scaffold Go CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/dna
+/coverage.out
+/dist/
+/bin/
+*.test
+*.prof
+
+.DS_Store
+.idea/
+.vscode/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# Agent Notes
+
+This repository is a Go prototype of Differential Network Analysis (DNA), based
+on Zhang et al., NSDI 2022. The project goal is to report forwarding-behavior
+changes caused by network control-plane changes.
+
+## Current State
+
+- Language: Go.
+- CLI framework: Cobra.
+- Entrypoint: `cmd/dna`.
+- CLI package: `internal/cli`.
+- Current implemented scope: scaffold only.
+- `dna diff` exists as a command shape but intentionally returns "not
+  implemented yet" when executed.
+- The paper PDF in the repository is reference material and should not be
+  modified unless explicitly requested.
+
+## Planned Architecture
+
+- Use Batfish only as a vendor configuration parser/normalizer.
+- Keep Batfish out of incremental recomputation and property checking.
+- Use Containerlab topology files as the first topology adapter.
+- Keep the internal topology model independent of Containerlab.
+- Include VRF in core models from the beginning.
+- Start protocol support with static and connected routes, then add OSPF, then
+  BGP.
+- Use prefix-based equivalence classes for the MVP.
+- Build a minimal DNA-specific Datalog/DDlog-like parser and evaluator in Go
+  rather than depending on DDlog.
+
+## Useful Commands
+
+```sh
+go test ./...
+go run ./cmd/dna --help
+go run ./cmd/dna diff --help
+golangci-lint run ./...
+```
+
+`go test` and `go run` may need access to the standard Go build cache outside
+the repository sandbox.
+
+## Development Conventions
+
+- Prefer small, issue-scoped changes.
+- Keep issue #1 scaffold-only; do not add routing or topology behavior there.
+- Place executable entrypoints under `cmd/`.
+- Place project internals under `internal/`.
+- Use `net/netip` for IP and prefix modeling when domain types are added.
+- Keep CLI output deterministic so it can be used in golden tests.
+- Run `go fmt ./...` before final verification.
+
+## GitHub Issues
+
+The roadmap is tracked in GitHub issues. The first implementation sequence is:
+
+1. Scaffold Go CLI and project layout.
+2. Define core fact schema and VRF-aware domain model.
+3. Implement Containerlab topology adapter.
+4. Add normalized config snapshot loader.
+5. Build minimal DNA-specific Datalog parser and relation engine.
+6. Derive static and connected forwarding rules.
+7. Build forwarding graph and full reachability checker.
+8. Implement snapshot diff output for reachability facts.
+9. Add incremental delta engine and change-point traversal.
+10. Implement Batfish parser adapter.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test lint fmt run
+
+test:
+	go test ./...
+
+lint:
+	golangci-lint run ./...
+
+fmt:
+	go fmt ./...
+
+run:
+	go run ./cmd/dna --help

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# dna
+
+`dna` is a prototype implementation of Differential Network Analysis, based on
+the NSDI 2022 paper by Zhang et al.
+
+The project goal is to report forwarding-behavior changes caused by network
+control-plane changes. The first milestone is only the Go CLI scaffold. Routing
+models, topology loading, Batfish parsing, reachability checking, and
+incremental analysis are planned for later milestones.
+
+## Design Direction
+
+- Use Batfish only as a vendor configuration parser/normalizer.
+- Use Containerlab topology files as the first topology input.
+- Keep topology and parser adapters behind internal models.
+- Include VRF in the core data model from the beginning.
+- Start with static and connected routes, then add OSPF and BGP.
+- Use prefix-based equivalence classes for the MVP.
+- Implement the minimal DNA-specific Datalog/DDlog-like engine in Go.
+
+## Current CLI
+
+```sh
+go run ./cmd/dna --help
+go run ./cmd/dna diff --help
+```
+
+The planned first operator workflow is:
+
+```sh
+dna diff \
+  --topology topology.clab.yaml \
+  --old-configs configs/old \
+  --new-configs configs/new
+```
+
+At this stage, `dna diff` is intentionally not implemented.
+
+## Development
+
+Run tests:
+
+```sh
+go test ./...
+```
+
+Run lint, if `golangci-lint` is installed:
+
+```sh
+golangci-lint run ./...
+```
+
+Run formatting:
+
+```sh
+go fmt ./...
+```
+
+The same commands are available as Make targets:
+
+```sh
+make test
+make lint
+make fmt
+make run
+```

--- a/cmd/dna/main.go
+++ b/cmd/dna/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/81ueman/dna/internal/cli"
+)
+
+func main() {
+	if err := cli.NewRootCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/81ueman/dna
+
+go 1.25
+
+require github.com/spf13/cobra v1.10.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewRootCommand builds the top-level dna command.
+func NewRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dna",
+		Short: "Differential Network Analysis prototype",
+		Long: "dna is a prototype implementation of Differential Network Analysis " +
+			"for reporting forwarding-behavior changes caused by network changes.",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(newDiffCommand())
+
+	return cmd
+}
+
+func newDiffCommand() *cobra.Command {
+	var opts diffOptions
+
+	cmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Compare old and new network snapshots",
+		Long: "Compare old and new network snapshots and report differential " +
+			"reachability facts. This scaffold only defines the command shape.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiff(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.topology, "topology", "", "path to a Containerlab topology file")
+	cmd.Flags().StringVar(&opts.oldConfigs, "old-configs", "", "path to the old configuration snapshot directory")
+	cmd.Flags().StringVar(&opts.newConfigs, "new-configs", "", "path to the new configuration snapshot directory")
+
+	return cmd
+}
+
+type diffOptions struct {
+	topology   string
+	oldConfigs string
+	newConfigs string
+}
+
+func runDiff(opts diffOptions) error {
+	return fmt.Errorf("dna diff is not implemented yet")
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRootHelp(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("root help returned error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "dna") {
+		t.Fatalf("root help does not mention command name; got:\n%s", got)
+	}
+	if !strings.Contains(got, "diff") {
+		t.Fatalf("root help does not mention diff subcommand; got:\n%s", got)
+	}
+}
+
+func TestDiffHelp(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"diff", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diff help returned error: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"--topology", "--old-configs", "--new-configs"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("diff help does not mention %s; got:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- scaffold the Go module and Cobra-based dna CLI
- add the stub dna diff command with planned snapshot flags
- add README, AGENTS.md, Makefile, gitignore, and golangci-lint config

## Validation
- go test ./...
- golangci-lint run ./...
- go run ./cmd/dna --help
- go run ./cmd/dna diff --help

## Notes
The repository was empty, so I pushed an empty initial main commit first to create a PR base. The paper PDF remains untracked and is not included in this PR.