### PR TITLE
[codex] Add core domain model

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,0 +1,175 @@
+package model
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// Typed identifiers keep fact fields readable while remaining comparable.
+type (
+	NodeID      string
+	VRF         string
+	InterfaceID string
+	EdgePortID  string
+)
+
+const DefaultVRF VRF = "default"
+
+type Node struct {
+	ID NodeID
+}
+
+func (n Node) String() string {
+	return fmt.Sprintf("Node{ID:%s}", n.ID)
+}
+
+type Interface struct {
+	Node NodeID
+	ID   InterfaceID
+	VRF  VRF
+}
+
+func (i Interface) String() string {
+	return fmt.Sprintf("Interface{Node:%s ID:%s VRF:%s}", i.Node, i.ID, i.VRF)
+}
+
+type Link struct {
+	NodeA      NodeID
+	InterfaceA InterfaceID
+	NodeB      NodeID
+	InterfaceB InterfaceID
+}
+
+func (l Link) String() string {
+	return fmt.Sprintf(
+		"Link{NodeA:%s InterfaceA:%s NodeB:%s InterfaceB:%s}",
+		l.NodeA,
+		l.InterfaceA,
+		l.NodeB,
+		l.InterfaceB,
+	)
+}
+
+type EdgePort struct {
+	ID        EdgePortID
+	Node      NodeID
+	Interface InterfaceID
+	VRF       VRF
+}
+
+func (e EdgePort) String() string {
+	return fmt.Sprintf(
+		"EdgePort{ID:%s Node:%s Interface:%s VRF:%s}",
+		e.ID,
+		e.Node,
+		e.Interface,
+		e.VRF,
+	)
+}
+
+type InterfaceAddress struct {
+	Node      NodeID
+	Interface InterfaceID
+	VRF       VRF
+	Prefix    netip.Prefix
+}
+
+func (a InterfaceAddress) String() string {
+	return fmt.Sprintf(
+		"InterfaceAddress{Node:%s Interface:%s VRF:%s Prefix:%s}",
+		a.Node,
+		a.Interface,
+		a.VRF,
+		a.Prefix,
+	)
+}
+
+type InterfaceState struct {
+	Node      NodeID
+	Interface InterfaceID
+	Up        bool
+}
+
+func (s InterfaceState) String() string {
+	return fmt.Sprintf("InterfaceState{Node:%s Interface:%s Up:%t}", s.Node, s.Interface, s.Up)
+}
+
+type StaticRoute struct {
+	Node    NodeID
+	VRF     VRF
+	Prefix  netip.Prefix
+	NextHop netip.Addr
+}
+
+func (r StaticRoute) String() string {
+	return fmt.Sprintf(
+		"StaticRoute{Node:%s VRF:%s Prefix:%s NextHop:%s}",
+		r.Node,
+		r.VRF,
+		r.Prefix,
+		r.NextHop,
+	)
+}
+
+type ConnectedRoute struct {
+	Node      NodeID
+	VRF       VRF
+	Prefix    netip.Prefix
+	Interface InterfaceID
+}
+
+func (r ConnectedRoute) String() string {
+	return fmt.Sprintf(
+		"ConnectedRoute{Node:%s VRF:%s Prefix:%s Interface:%s}",
+		r.Node,
+		r.VRF,
+		r.Prefix,
+		r.Interface,
+	)
+}
+
+type ForwardAction string
+
+const (
+	ForwardActionNextHop   ForwardAction = "next-hop"
+	ForwardActionInterface ForwardAction = "interface"
+	ForwardActionDrop      ForwardAction = "drop"
+)
+
+type ForwardingRule struct {
+	Node      NodeID
+	VRF       VRF
+	Prefix    netip.Prefix
+	Action    ForwardAction
+	NextHop   netip.Addr
+	Interface InterfaceID
+}
+
+func (r ForwardingRule) String() string {
+	return fmt.Sprintf(
+		"ForwardingRule{Node:%s VRF:%s Prefix:%s Action:%s NextHop:%s Interface:%s}",
+		r.Node,
+		r.VRF,
+		r.Prefix,
+		r.Action,
+		r.NextHop,
+		r.Interface,
+	)
+}
+
+type Reach struct {
+	Source EdgePortID
+	Dest   EdgePortID
+	VRF    VRF
+	Prefix netip.Prefix
+}
+
+func (r Reach) String() string {
+	return fmt.Sprintf(
+		"Reach{Source:%s Dest:%s VRF:%s Prefix:%s}",
+		r.Source,
+		r.Dest,
+		r.VRF,
+		r.Prefix,
+	)
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,186 @@
+package model
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func mustPrefix(t *testing.T, raw string) netip.Prefix {
+	t.Helper()
+
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		t.Fatalf("parse prefix %q: %v", raw, err)
+	}
+
+	return prefix.Masked()
+}
+
+func mustAddr(t *testing.T, raw string) netip.Addr {
+	t.Helper()
+
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		t.Fatalf("parse addr %q: %v", raw, err)
+	}
+
+	return addr
+}
+
+func TestIdentifiersAreMapKeys(t *testing.T) {
+	nodes := map[NodeID]Node{
+		"r1": {ID: "r1"},
+	}
+	interfaces := map[InterfaceID]Interface{
+		"Ethernet1": {Node: "r1", ID: "Ethernet1", VRF: DefaultVRF},
+	}
+	edgePorts := map[EdgePortID]EdgePort{
+		"h1": {ID: "h1", Node: "r1", Interface: "Ethernet1", VRF: DefaultVRF},
+	}
+
+	if nodes["r1"].ID != "r1" {
+		t.Fatalf("unexpected node lookup: %#v", nodes["r1"])
+	}
+	if interfaces["Ethernet1"].VRF != DefaultVRF {
+		t.Fatalf("unexpected interface lookup: %#v", interfaces["Ethernet1"])
+	}
+	if edgePorts["h1"].Node != "r1" {
+		t.Fatalf("unexpected edge port lookup: %#v", edgePorts["h1"])
+	}
+}
+
+func TestDefaultVRF(t *testing.T) {
+	if DefaultVRF != "default" {
+		t.Fatalf("DefaultVRF = %q, want default", DefaultVRF)
+	}
+}
+
+func TestPrefixNormalization(t *testing.T) {
+	prefix := mustPrefix(t, "10.0.0.42/24")
+	want := netip.MustParsePrefix("10.0.0.0/24")
+
+	if prefix != want {
+		t.Fatalf("normalized prefix = %s, want %s", prefix, want)
+	}
+}
+
+func TestComparableFacts(t *testing.T) {
+	route := StaticRoute{
+		Node:    "r1",
+		VRF:     DefaultVRF,
+		Prefix:  mustPrefix(t, "10.0.0.0/24"),
+		NextHop: mustAddr(t, "192.0.2.1"),
+	}
+
+	routes := map[StaticRoute]bool{route: true}
+	if !routes[route] {
+		t.Fatalf("static route was not usable as a map key")
+	}
+}
+
+func TestFactStrings(t *testing.T) {
+	prefix := mustPrefix(t, "10.0.0.0/24")
+	nextHop := mustAddr(t, "192.0.2.1")
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "node",
+			got:  Node{ID: "r1"}.String(),
+			want: "Node{ID:r1}",
+		},
+		{
+			name: "interface",
+			got:  Interface{Node: "r1", ID: "Ethernet1", VRF: DefaultVRF}.String(),
+			want: "Interface{Node:r1 ID:Ethernet1 VRF:default}",
+		},
+		{
+			name: "link",
+			got: Link{
+				NodeA:      "r1",
+				InterfaceA: "Ethernet1",
+				NodeB:      "r2",
+				InterfaceB: "Ethernet2",
+			}.String(),
+			want: "Link{NodeA:r1 InterfaceA:Ethernet1 NodeB:r2 InterfaceB:Ethernet2}",
+		},
+		{
+			name: "edge port",
+			got: EdgePort{
+				ID:        "h1",
+				Node:      "r1",
+				Interface: "Ethernet1",
+				VRF:       DefaultVRF,
+			}.String(),
+			want: "EdgePort{ID:h1 Node:r1 Interface:Ethernet1 VRF:default}",
+		},
+		{
+			name: "interface address",
+			got: InterfaceAddress{
+				Node:      "r1",
+				Interface: "Ethernet1",
+				VRF:       DefaultVRF,
+				Prefix:    prefix,
+			}.String(),
+			want: "InterfaceAddress{Node:r1 Interface:Ethernet1 VRF:default Prefix:10.0.0.0/24}",
+		},
+		{
+			name: "interface state",
+			got:  InterfaceState{Node: "r1", Interface: "Ethernet1", Up: true}.String(),
+			want: "InterfaceState{Node:r1 Interface:Ethernet1 Up:true}",
+		},
+		{
+			name: "static route",
+			got: StaticRoute{
+				Node:    "r1",
+				VRF:     DefaultVRF,
+				Prefix:  prefix,
+				NextHop: nextHop,
+			}.String(),
+			want: "StaticRoute{Node:r1 VRF:default Prefix:10.0.0.0/24 NextHop:192.0.2.1}",
+		},
+		{
+			name: "connected route",
+			got: ConnectedRoute{
+				Node:      "r1",
+				VRF:       DefaultVRF,
+				Prefix:    prefix,
+				Interface: "Ethernet1",
+			}.String(),
+			want: "ConnectedRoute{Node:r1 VRF:default Prefix:10.0.0.0/24 Interface:Ethernet1}",
+		},
+		{
+			name: "forwarding rule",
+			got: ForwardingRule{
+				Node:      "r1",
+				VRF:       DefaultVRF,
+				Prefix:    prefix,
+				Action:    ForwardActionNextHop,
+				NextHop:   nextHop,
+				Interface: "Ethernet1",
+			}.String(),
+			want: "ForwardingRule{Node:r1 VRF:default Prefix:10.0.0.0/24 Action:next-hop NextHop:192.0.2.1 Interface:Ethernet1}",
+		},
+		{
+			name: "reach",
+			got: Reach{
+				Source: "h1",
+				Dest:   "h2",
+				VRF:    DefaultVRF,
+				Prefix: prefix,
+			}.String(),
+			want: "Reach{Source:h1 Dest:h2 VRF:default Prefix:10.0.0.0/24}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("String() = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add VRF-aware core model types for topology, route, forwarding, and reachability facts
- use typed string identifiers and Go net/netip for prefixes and next-hop addresses
- add deterministic Go-style String methods and unit tests

Closes #2

## Validation
- go test ./...
- golangci-lint run ./...

## Notes
This PR only adds shared model contracts. It does not implement topology loading, routing, reachability traversal, Datalog evaluation, or Batfish integration.