### PR TITLE
[codex] Add Containerlab topology adapter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/81ueman/dna
 
 go 1.25
 
-require github.com/spf13/cobra v1.10.1
+require (
+	github.com/spf13/cobra v1.10.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/topology/containerlab.go
+++ b/internal/topology/containerlab.go
@@ -46,6 +46,10 @@ func ParseContainerlab(data []byte, opts LoadOptions) (Topology, error) {
 		}
 	}
 
+	if len(input.Topology.Nodes) == 0 {
+		return Topology{}, fmt.Errorf("topology.nodes must declare at least one node")
+	}
+
 	builder := newBuilder(normalize)
 	for nodeName := range input.Topology.Nodes {
 		if nodeName == "" {

--- a/internal/topology/containerlab.go
+++ b/internal/topology/containerlab.go
@@ -1,0 +1,309 @@
+package topology
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/81ueman/dna/internal/model"
+	"gopkg.in/yaml.v3"
+)
+
+type InterfaceNormalizer func(node model.NodeID, iface model.InterfaceID) model.InterfaceID
+
+type LoadOptions struct {
+	NormalizeInterface InterfaceNormalizer
+}
+
+type Topology struct {
+	Nodes           []model.Node
+	Interfaces      []model.Interface
+	Links           []model.Link
+	EdgePorts       []model.EdgePort
+	NodeConfigNames map[model.NodeID]string
+}
+
+func LoadContainerlab(path string, opts LoadOptions) (Topology, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Topology{}, fmt.Errorf("read containerlab topology: %w", err)
+	}
+
+	return ParseContainerlab(data, opts)
+}
+
+func ParseContainerlab(data []byte, opts LoadOptions) (Topology, error) {
+	var input containerlabFile
+	if err := yaml.Unmarshal(data, &input); err != nil {
+		return Topology{}, fmt.Errorf("parse containerlab topology: %w", err)
+	}
+
+	normalize := opts.NormalizeInterface
+	if normalize == nil {
+		normalize = func(_ model.NodeID, iface model.InterfaceID) model.InterfaceID {
+			return iface
+		}
+	}
+
+	builder := newBuilder(normalize)
+	for nodeName := range input.Topology.Nodes {
+		if nodeName == "" {
+			return Topology{}, fmt.Errorf("node name must not be empty")
+		}
+		builder.addNode(model.NodeID(nodeName))
+	}
+
+	for i, link := range input.Topology.Links {
+		if len(link.Endpoints) != 2 {
+			return Topology{}, fmt.Errorf("link %d must have exactly 2 endpoints, got %d", i, len(link.Endpoints))
+		}
+
+		a, err := parseEndpoint(link.Endpoints[0], normalize)
+		if err != nil {
+			return Topology{}, fmt.Errorf("link %d endpoint 0: %w", i, err)
+		}
+		b, err := parseEndpoint(link.Endpoints[1], normalize)
+		if err != nil {
+			return Topology{}, fmt.Errorf("link %d endpoint 1: %w", i, err)
+		}
+		if !builder.hasNode(a.node) {
+			return Topology{}, fmt.Errorf("link %d references unknown node %q", i, a.node)
+		}
+		if !builder.hasNode(b.node) {
+			return Topology{}, fmt.Errorf("link %d references unknown node %q", i, b.node)
+		}
+
+		builder.addInterface(a.node, a.iface, model.DefaultVRF)
+		builder.addInterface(b.node, b.iface, model.DefaultVRF)
+		builder.addLink(a.node, a.iface, b.node, b.iface)
+		builder.addLink(b.node, b.iface, a.node, a.iface)
+	}
+
+	for i, edgePort := range input.XDNA.EdgePorts {
+		edge, err := edgePort.toModel(i, normalize)
+		if err != nil {
+			return Topology{}, err
+		}
+		if !builder.hasNode(edge.Node) {
+			return Topology{}, fmt.Errorf("edge port %q references unknown node %q", edge.ID, edge.Node)
+		}
+		if builder.hasEdgePort(edge.ID) {
+			return Topology{}, fmt.Errorf("duplicate edge port %q", edge.ID)
+		}
+
+		builder.addInterface(edge.Node, edge.Interface, edge.VRF)
+		builder.addEdgePort(edge)
+	}
+
+	for nodeName, configName := range input.XDNA.NodeConfigNames {
+		node := model.NodeID(nodeName)
+		if !builder.hasNode(node) {
+			return Topology{}, fmt.Errorf("node config mapping references unknown node %q", node)
+		}
+		builder.addNodeConfigName(node, configName)
+	}
+
+	return builder.build(), nil
+}
+
+type containerlabFile struct {
+	Topology struct {
+		Nodes map[string]yaml.Node `yaml:"nodes"`
+		Links []struct {
+			Endpoints []string `yaml:"endpoints"`
+		} `yaml:"links"`
+	} `yaml:"topology"`
+	XDNA struct {
+		EdgePorts       []edgePortYAML    `yaml:"edge_ports"`
+		NodeConfigNames map[string]string `yaml:"node_config_names"`
+	} `yaml:"x-dna"`
+}
+
+type edgePortYAML struct {
+	Name      string `yaml:"name"`
+	Node      string `yaml:"node"`
+	Interface string `yaml:"interface"`
+	VRF       string `yaml:"vrf"`
+}
+
+func (e edgePortYAML) toModel(index int, normalize InterfaceNormalizer) (model.EdgePort, error) {
+	if e.Name == "" {
+		return model.EdgePort{}, fmt.Errorf("edge port %d missing name", index)
+	}
+	if e.Node == "" {
+		return model.EdgePort{}, fmt.Errorf("edge port %q missing node", e.Name)
+	}
+	if e.Interface == "" {
+		return model.EdgePort{}, fmt.Errorf("edge port %q missing interface", e.Name)
+	}
+
+	node := model.NodeID(e.Node)
+	vrf := model.VRF(e.VRF)
+	if vrf == "" {
+		vrf = model.DefaultVRF
+	}
+
+	return model.EdgePort{
+		ID:        model.EdgePortID(e.Name),
+		Node:      node,
+		Interface: normalize(node, model.InterfaceID(e.Interface)),
+		VRF:       vrf,
+	}, nil
+}
+
+type endpoint struct {
+	node  model.NodeID
+	iface model.InterfaceID
+}
+
+func parseEndpoint(raw string, normalize InterfaceNormalizer) (endpoint, error) {
+	nodeName, ifaceName, ok := strings.Cut(raw, ":")
+	if !ok {
+		return endpoint{}, fmt.Errorf("endpoint %q must be in node:interface form", raw)
+	}
+	if nodeName == "" {
+		return endpoint{}, fmt.Errorf("endpoint %q has empty node", raw)
+	}
+	if ifaceName == "" {
+		return endpoint{}, fmt.Errorf("endpoint %q has empty interface", raw)
+	}
+
+	node := model.NodeID(nodeName)
+	return endpoint{
+		node:  node,
+		iface: normalize(node, model.InterfaceID(ifaceName)),
+	}, nil
+}
+
+type builder struct {
+	normalize       InterfaceNormalizer
+	nodes           map[model.NodeID]model.Node
+	interfaces      map[interfaceKey]model.Interface
+	links           map[linkKey]model.Link
+	edgePorts       map[model.EdgePortID]model.EdgePort
+	nodeConfigNames map[model.NodeID]string
+}
+
+func newBuilder(normalize InterfaceNormalizer) *builder {
+	return &builder{
+		normalize:       normalize,
+		nodes:           map[model.NodeID]model.Node{},
+		interfaces:      map[interfaceKey]model.Interface{},
+		links:           map[linkKey]model.Link{},
+		edgePorts:       map[model.EdgePortID]model.EdgePort{},
+		nodeConfigNames: map[model.NodeID]string{},
+	}
+}
+
+func (b *builder) addNode(id model.NodeID) {
+	b.nodes[id] = model.Node{ID: id}
+}
+
+func (b *builder) hasNode(id model.NodeID) bool {
+	_, ok := b.nodes[id]
+	return ok
+}
+
+func (b *builder) addInterface(node model.NodeID, iface model.InterfaceID, vrf model.VRF) {
+	b.interfaces[interfaceKey{node: node, iface: iface, vrf: vrf}] = model.Interface{
+		Node: node,
+		ID:   iface,
+		VRF:  vrf,
+	}
+}
+
+func (b *builder) addLink(nodeA model.NodeID, ifaceA model.InterfaceID, nodeB model.NodeID, ifaceB model.InterfaceID) {
+	b.links[linkKey{nodeA: nodeA, ifaceA: ifaceA, nodeB: nodeB, ifaceB: ifaceB}] = model.Link{
+		NodeA:      nodeA,
+		InterfaceA: ifaceA,
+		NodeB:      nodeB,
+		InterfaceB: ifaceB,
+	}
+}
+
+func (b *builder) addEdgePort(edge model.EdgePort) {
+	b.edgePorts[edge.ID] = edge
+}
+
+func (b *builder) hasEdgePort(id model.EdgePortID) bool {
+	_, ok := b.edgePorts[id]
+	return ok
+}
+
+func (b *builder) addNodeConfigName(node model.NodeID, configName string) {
+	b.nodeConfigNames[node] = configName
+}
+
+func (b *builder) build() Topology {
+	nodes := valuesSorted(b.nodes, func(a, c model.Node) bool {
+		return a.ID < c.ID
+	})
+	interfaces := valuesSorted(b.interfaces, func(a, c model.Interface) bool {
+		if a.Node != c.Node {
+			return a.Node < c.Node
+		}
+		if a.ID != c.ID {
+			return a.ID < c.ID
+		}
+		return a.VRF < c.VRF
+	})
+	links := valuesSorted(b.links, func(a, c model.Link) bool {
+		if a.NodeA != c.NodeA {
+			return a.NodeA < c.NodeA
+		}
+		if a.InterfaceA != c.InterfaceA {
+			return a.InterfaceA < c.InterfaceA
+		}
+		if a.NodeB != c.NodeB {
+			return a.NodeB < c.NodeB
+		}
+		return a.InterfaceB < c.InterfaceB
+	})
+	edgePorts := valuesSorted(b.edgePorts, func(a, c model.EdgePort) bool {
+		return a.ID < c.ID
+	})
+
+	return Topology{
+		Nodes:           nodes,
+		Interfaces:      interfaces,
+		Links:           links,
+		EdgePorts:       edgePorts,
+		NodeConfigNames: cloneMap(b.nodeConfigNames),
+	}
+}
+
+type interfaceKey struct {
+	node  model.NodeID
+	iface model.InterfaceID
+	vrf   model.VRF
+}
+
+type linkKey struct {
+	nodeA  model.NodeID
+	ifaceA model.InterfaceID
+	nodeB  model.NodeID
+	ifaceB model.InterfaceID
+}
+
+func valuesSorted[M ~map[K]V, K comparable, V any](m M, less func(a, b V) bool) []V {
+	values := make([]V, 0, len(m))
+	for _, value := range m {
+		values = append(values, value)
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return less(values[i], values[j])
+	})
+	return values
+}
+
+func cloneMap[K comparable, V any](m map[K]V) map[K]V {
+	if len(m) == 0 {
+		return nil
+	}
+	clone := make(map[K]V, len(m))
+	for key, value := range m {
+		clone[key] = value
+	}
+	return clone
+}

--- a/internal/topology/containerlab_test.go
+++ b/internal/topology/containerlab_test.go
@@ -1,0 +1,223 @@
+package topology
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/81ueman/dna/internal/model"
+)
+
+func TestParseContainerlab(t *testing.T) {
+	const input = `
+name: demo
+topology:
+  nodes:
+    r2:
+      kind: ceos
+    r1:
+      kind: ceos
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+x-dna:
+  edge_ports:
+    - name: h2
+      node: r2
+      interface: eth2
+      vrf: blue
+    - name: h1
+      node: r1
+      interface: eth2
+  node_config_names:
+    r1: leaf1
+    r2: leaf2
+`
+
+	topo, err := ParseContainerlab([]byte(input), LoadOptions{})
+	if err != nil {
+		t.Fatalf("parse containerlab: %v", err)
+	}
+
+	assertEqual(t, topo.Nodes, []model.Node{
+		{ID: "r1"},
+		{ID: "r2"},
+	})
+	assertEqual(t, topo.Links, []model.Link{
+		{NodeA: "r1", InterfaceA: "eth1", NodeB: "r2", InterfaceB: "eth1"},
+		{NodeA: "r2", InterfaceA: "eth1", NodeB: "r1", InterfaceB: "eth1"},
+	})
+	assertEqual(t, topo.EdgePorts, []model.EdgePort{
+		{ID: "h1", Node: "r1", Interface: "eth2", VRF: model.DefaultVRF},
+		{ID: "h2", Node: "r2", Interface: "eth2", VRF: "blue"},
+	})
+	assertEqual(t, topo.Interfaces, []model.Interface{
+		{Node: "r1", ID: "eth1", VRF: model.DefaultVRF},
+		{Node: "r1", ID: "eth2", VRF: model.DefaultVRF},
+		{Node: "r2", ID: "eth1", VRF: model.DefaultVRF},
+		{Node: "r2", ID: "eth2", VRF: "blue"},
+	})
+
+	if topo.NodeConfigNames["r1"] != "leaf1" {
+		t.Fatalf("r1 config name = %q, want leaf1", topo.NodeConfigNames["r1"])
+	}
+	if topo.NodeConfigNames["r2"] != "leaf2" {
+		t.Fatalf("r2 config name = %q, want leaf2", topo.NodeConfigNames["r2"])
+	}
+}
+
+func TestParseContainerlabNormalizesInterfaces(t *testing.T) {
+	const input = `
+topology:
+  nodes:
+    r1: {}
+    r2: {}
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+x-dna:
+  edge_ports:
+    - name: h1
+      node: r1
+      interface: eth2
+`
+
+	topo, err := ParseContainerlab([]byte(input), LoadOptions{
+		NormalizeInterface: func(_ model.NodeID, iface model.InterfaceID) model.InterfaceID {
+			return model.InterfaceID(strings.ReplaceAll(string(iface), "eth", "Ethernet"))
+		},
+	})
+	if err != nil {
+		t.Fatalf("parse containerlab: %v", err)
+	}
+
+	assertEqual(t, topo.Links, []model.Link{
+		{NodeA: "r1", InterfaceA: "Ethernet1", NodeB: "r2", InterfaceB: "Ethernet1"},
+		{NodeA: "r2", InterfaceA: "Ethernet1", NodeB: "r1", InterfaceB: "Ethernet1"},
+	})
+	assertEqual(t, topo.EdgePorts, []model.EdgePort{
+		{ID: "h1", Node: "r1", Interface: "Ethernet2", VRF: model.DefaultVRF},
+	})
+}
+
+func TestParseContainerlabValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "malformed endpoint",
+			input: `
+topology:
+  nodes:
+    r1: {}
+    r2: {}
+  links:
+    - endpoints: ["r1eth1", "r2:eth1"]
+`,
+			wantErr: "node:interface",
+		},
+		{
+			name: "unknown link node",
+			input: `
+topology:
+  nodes:
+    r1: {}
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+`,
+			wantErr: `unknown node "r2"`,
+		},
+		{
+			name: "one ended link",
+			input: `
+topology:
+  nodes:
+    r1: {}
+  links:
+    - endpoints: ["r1:eth1"]
+`,
+			wantErr: "exactly 2 endpoints",
+		},
+		{
+			name: "three ended link",
+			input: `
+topology:
+  nodes:
+    r1: {}
+    r2: {}
+    r3: {}
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1", "r3:eth1"]
+`,
+			wantErr: "exactly 2 endpoints",
+		},
+		{
+			name: "unknown edge node",
+			input: `
+topology:
+  nodes:
+    r1: {}
+x-dna:
+  edge_ports:
+    - name: h1
+      node: r2
+      interface: eth1
+`,
+			wantErr: `unknown node "r2"`,
+		},
+		{
+			name: "duplicate edge port",
+			input: `
+topology:
+  nodes:
+    r1: {}
+x-dna:
+  edge_ports:
+    - name: h1
+      node: r1
+      interface: eth1
+    - name: h1
+      node: r1
+      interface: eth2
+`,
+			wantErr: `duplicate edge port "h1"`,
+		},
+		{
+			name: "missing edge field",
+			input: `
+topology:
+  nodes:
+    r1: {}
+x-dna:
+  edge_ports:
+    - name: h1
+      node: r1
+`,
+			wantErr: "missing interface",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseContainerlab([]byte(tt.input), LoadOptions{})
+			if err == nil {
+				t.Fatalf("ParseContainerlab succeeded, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func assertEqual[T comparable](t *testing.T, got, want []T) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d\ngot:  %#v\nwant: %#v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("item %d = %#v, want %#v\ngot:  %#v\nwant: %#v", i, got[i], want[i], got, want)
+		}
+	}
+}

--- a/internal/topology/containerlab_test.go
+++ b/internal/topology/containerlab_test.go
@@ -104,6 +104,28 @@ func TestParseContainerlabValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name:    "empty file",
+			input:   "",
+			wantErr: "topology.nodes",
+		},
+		{
+			name: "missing nodes",
+			input: `
+topology:
+  links: []
+`,
+			wantErr: "topology.nodes",
+		},
+		{
+			name: "misspelled nodes",
+			input: `
+topology:
+  nodez:
+    r1: {}
+`,
+			wantErr: "topology.nodes",
+		},
+		{
 			name: "malformed endpoint",
 			input: `
 topology:


### PR DESCRIPTION
## Summary
- add a Containerlab topology adapter that emits model-backed topology data
- parse nodes, bidirectional links, x-dna edge ports, and node config mappings
- add validation for malformed endpoints, unknown nodes, invalid link endpoint counts, duplicate edge ports, and missing edge port fields

Closes #5

## Validation
- go test ./...
- golangci-lint run ./...

## Notes
This PR does not wire topology loading into the CLI and does not implement config loading, routing, reachability traversal, Datalog evaluation, or Batfish integration.