### PR TITLE
[codex] Add normalized config loader

### DIFF
--- a/internal/config/normalized.go
+++ b/internal/config/normalized.go
@@ -80,10 +80,10 @@ func parseNodeConfig(data []byte, topo topology.Topology) (model.NodeID, Snapsho
 		return "", Snapshot{}, fmt.Errorf("node is required")
 	}
 
-	node := model.NodeID(input.Node)
 	validator := newValidator(topo)
-	if !validator.hasNode(node) {
-		return "", Snapshot{}, fmt.Errorf("node %q not found in topology", node)
+	node, ok := validator.resolveNode(input.Node)
+	if !ok {
+		return "", Snapshot{}, fmt.Errorf("node %q not found in topology", input.Node)
 	}
 
 	var snapshot Snapshot
@@ -264,25 +264,38 @@ func (s *Snapshot) sort() {
 }
 
 type validator struct {
-	nodes      map[model.NodeID]bool
-	interfaces map[interfaceKey]bool
-	vrfs       map[vrfKey]bool
+	nodes       map[model.NodeID]bool
+	configNames map[string]model.NodeID
+	interfaces  map[interfaceKey]bool
+	vrfs        map[vrfKey]bool
 }
 
 func newValidator(topo topology.Topology) validator {
 	v := validator{
-		nodes:      map[model.NodeID]bool{},
-		interfaces: map[interfaceKey]bool{},
-		vrfs:       map[vrfKey]bool{},
+		nodes:       map[model.NodeID]bool{},
+		configNames: map[string]model.NodeID{},
+		interfaces:  map[interfaceKey]bool{},
+		vrfs:        map[vrfKey]bool{},
 	}
 	for _, node := range topo.Nodes {
 		v.nodes[node.ID] = true
+		v.configNames[string(node.ID)] = node.ID
+	}
+	for node, configName := range topo.NodeConfigNames {
+		if configName != "" {
+			v.configNames[configName] = node
+		}
 	}
 	for _, iface := range topo.Interfaces {
 		v.interfaces[interfaceKey{node: iface.Node, iface: iface.ID, vrf: iface.VRF}] = true
 		v.vrfs[vrfKey{node: iface.Node, vrf: iface.VRF}] = true
 	}
 	return v
+}
+
+func (v validator) resolveNode(name string) (model.NodeID, bool) {
+	node, ok := v.configNames[name]
+	return node, ok
 }
 
 func (v validator) hasNode(node model.NodeID) bool {

--- a/internal/config/normalized.go
+++ b/internal/config/normalized.go
@@ -60,6 +60,12 @@ func LoadSnapshotDir(path string, topo topology.Topology) (Snapshot, error) {
 		snapshot.append(nodeSnapshot)
 	}
 
+	for _, node := range topo.Nodes {
+		if _, ok := seenNodes[node.ID]; !ok {
+			return Snapshot{}, fmt.Errorf("snapshot missing config for topology node %q", node.ID)
+		}
+	}
+
 	snapshot.sort()
 	return snapshot, nil
 }

--- a/internal/config/normalized.go
+++ b/internal/config/normalized.go
@@ -1,0 +1,322 @@
+package config
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/81ueman/dna/internal/model"
+	"github.com/81ueman/dna/internal/topology"
+	"gopkg.in/yaml.v3"
+)
+
+type Snapshot struct {
+	InterfaceAddresses []model.InterfaceAddress
+	InterfaceStates    []model.InterfaceState
+	ConnectedRoutes    []model.ConnectedRoute
+	StaticRoutes       []model.StaticRoute
+}
+
+func LoadSnapshotDir(path string, topo topology.Topology) (Snapshot, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("read snapshot directory: %w", err)
+	}
+
+	validator := newValidator(topo)
+	seenNodes := map[model.NodeID]string{}
+	var snapshot Snapshot
+
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAMLFile(entry.Name()) {
+			continue
+		}
+
+		filePath := filepath.Join(path, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("read node config %q: %w", entry.Name(), err)
+		}
+
+		nodeSnapshot, err := ParseNodeConfig(data, topo)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("parse node config %q: %w", entry.Name(), err)
+		}
+		node, err := nodeSnapshot.singleNode()
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("parse node config %q: %w", entry.Name(), err)
+		}
+		if firstFile, ok := seenNodes[node]; ok {
+			return Snapshot{}, fmt.Errorf("duplicate node %q in %q and %q", node, firstFile, entry.Name())
+		}
+		if !validator.hasNode(node) {
+			return Snapshot{}, fmt.Errorf("node %q not found in topology", node)
+		}
+		seenNodes[node] = entry.Name()
+
+		snapshot.append(nodeSnapshot)
+	}
+
+	snapshot.sort()
+	return snapshot, nil
+}
+
+func ParseNodeConfig(data []byte, topo topology.Topology) (Snapshot, error) {
+	var input nodeConfigYAML
+	if err := yaml.Unmarshal(data, &input); err != nil {
+		return Snapshot{}, fmt.Errorf("parse normalized config: %w", err)
+	}
+	if input.Node == "" {
+		return Snapshot{}, fmt.Errorf("node is required")
+	}
+
+	node := model.NodeID(input.Node)
+	validator := newValidator(topo)
+	if !validator.hasNode(node) {
+		return Snapshot{}, fmt.Errorf("node %q not found in topology", node)
+	}
+
+	var snapshot Snapshot
+	for ifaceName, iface := range input.Interfaces {
+		if ifaceName == "" {
+			return Snapshot{}, fmt.Errorf("interface name must not be empty")
+		}
+
+		interfaceID := model.InterfaceID(ifaceName)
+		vrf := defaultVRF(iface.VRF)
+		if !validator.hasInterface(node, interfaceID, vrf) {
+			return Snapshot{}, fmt.Errorf("interface %q in VRF %q on node %q not found in topology", interfaceID, vrf, node)
+		}
+
+		up := true
+		if iface.Up != nil {
+			up = *iface.Up
+		}
+		snapshot.InterfaceStates = append(snapshot.InterfaceStates, model.InterfaceState{
+			Node:      node,
+			Interface: interfaceID,
+			Up:        up,
+		})
+
+		for _, rawPrefix := range iface.Addresses {
+			prefix, err := parsePrefix(rawPrefix)
+			if err != nil {
+				return Snapshot{}, fmt.Errorf("interface %q address %q: %w", interfaceID, rawPrefix, err)
+			}
+			snapshot.InterfaceAddresses = append(snapshot.InterfaceAddresses, model.InterfaceAddress{
+				Node:      node,
+				Interface: interfaceID,
+				VRF:       vrf,
+				Prefix:    prefix,
+			})
+			snapshot.ConnectedRoutes = append(snapshot.ConnectedRoutes, model.ConnectedRoute{
+				Node:      node,
+				VRF:       vrf,
+				Prefix:    prefix,
+				Interface: interfaceID,
+			})
+		}
+	}
+
+	for i, route := range input.StaticRoutes {
+		vrf := defaultVRF(route.VRF)
+		if !validator.hasVRF(node, vrf) {
+			return Snapshot{}, fmt.Errorf("VRF %q on node %q not found in topology", vrf, node)
+		}
+		prefix, err := parsePrefix(route.Prefix)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("static route %d prefix %q: %w", i, route.Prefix, err)
+		}
+
+		hasNextHop := route.NextHop != ""
+		if hasNextHop == route.Drop {
+			return Snapshot{}, fmt.Errorf("static route %d must specify exactly one of next_hop or drop", i)
+		}
+
+		staticRoute := model.StaticRoute{
+			Node:   node,
+			VRF:    vrf,
+			Prefix: prefix,
+		}
+		if route.Drop {
+			staticRoute.Action = model.StaticRouteActionDrop
+		} else {
+			nextHop, err := netip.ParseAddr(route.NextHop)
+			if err != nil {
+				return Snapshot{}, fmt.Errorf("static route %d next_hop %q: %w", i, route.NextHop, err)
+			}
+			staticRoute.Action = model.StaticRouteActionNextHop
+			staticRoute.NextHop = nextHop
+		}
+		snapshot.StaticRoutes = append(snapshot.StaticRoutes, staticRoute)
+	}
+
+	snapshot.sort()
+	return snapshot, nil
+}
+
+type nodeConfigYAML struct {
+	Node         string                   `yaml:"node"`
+	Interfaces   map[string]interfaceYAML `yaml:"interfaces"`
+	StaticRoutes []staticRouteYAML        `yaml:"static_routes"`
+}
+
+type interfaceYAML struct {
+	VRF       string   `yaml:"vrf"`
+	Addresses []string `yaml:"addresses"`
+	Up        *bool    `yaml:"up"`
+}
+
+type staticRouteYAML struct {
+	VRF     string `yaml:"vrf"`
+	Prefix  string `yaml:"prefix"`
+	NextHop string `yaml:"next_hop"`
+	Drop    bool   `yaml:"drop"`
+}
+
+func defaultVRF(vrf string) model.VRF {
+	if vrf == "" {
+		return model.DefaultVRF
+	}
+	return model.VRF(vrf)
+}
+
+func parsePrefix(raw string) (netip.Prefix, error) {
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	return prefix.Masked(), nil
+}
+
+func isYAMLFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+func (s *Snapshot) append(other Snapshot) {
+	s.InterfaceAddresses = append(s.InterfaceAddresses, other.InterfaceAddresses...)
+	s.InterfaceStates = append(s.InterfaceStates, other.InterfaceStates...)
+	s.ConnectedRoutes = append(s.ConnectedRoutes, other.ConnectedRoutes...)
+	s.StaticRoutes = append(s.StaticRoutes, other.StaticRoutes...)
+}
+
+func (s Snapshot) singleNode() (model.NodeID, error) {
+	nodes := map[model.NodeID]bool{}
+	for _, fact := range s.InterfaceAddresses {
+		nodes[fact.Node] = true
+	}
+	for _, fact := range s.InterfaceStates {
+		nodes[fact.Node] = true
+	}
+	for _, fact := range s.ConnectedRoutes {
+		nodes[fact.Node] = true
+	}
+	for _, fact := range s.StaticRoutes {
+		nodes[fact.Node] = true
+	}
+	for node := range nodes {
+		return node, nil
+	}
+	return "", fmt.Errorf("node config produced no facts")
+}
+
+func (s *Snapshot) sort() {
+	sort.Slice(s.InterfaceAddresses, func(i, j int) bool {
+		a, b := s.InterfaceAddresses[i], s.InterfaceAddresses[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.Interface != b.Interface {
+			return a.Interface < b.Interface
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		return a.Prefix.String() < b.Prefix.String()
+	})
+	sort.Slice(s.InterfaceStates, func(i, j int) bool {
+		a, b := s.InterfaceStates[i], s.InterfaceStates[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		return a.Interface < b.Interface
+	})
+	sort.Slice(s.ConnectedRoutes, func(i, j int) bool {
+		a, b := s.ConnectedRoutes[i], s.ConnectedRoutes[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		if a.Prefix != b.Prefix {
+			return a.Prefix.String() < b.Prefix.String()
+		}
+		return a.Interface < b.Interface
+	})
+	sort.Slice(s.StaticRoutes, func(i, j int) bool {
+		a, b := s.StaticRoutes[i], s.StaticRoutes[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		if a.Prefix != b.Prefix {
+			return a.Prefix.String() < b.Prefix.String()
+		}
+		if a.Action != b.Action {
+			return a.Action < b.Action
+		}
+		return a.NextHop.String() < b.NextHop.String()
+	})
+}
+
+type validator struct {
+	nodes      map[model.NodeID]bool
+	interfaces map[interfaceKey]bool
+	vrfs       map[vrfKey]bool
+}
+
+func newValidator(topo topology.Topology) validator {
+	v := validator{
+		nodes:      map[model.NodeID]bool{},
+		interfaces: map[interfaceKey]bool{},
+		vrfs:       map[vrfKey]bool{},
+	}
+	for _, node := range topo.Nodes {
+		v.nodes[node.ID] = true
+	}
+	for _, iface := range topo.Interfaces {
+		v.interfaces[interfaceKey{node: iface.Node, iface: iface.ID, vrf: iface.VRF}] = true
+		v.vrfs[vrfKey{node: iface.Node, vrf: iface.VRF}] = true
+	}
+	return v
+}
+
+func (v validator) hasNode(node model.NodeID) bool {
+	return v.nodes[node]
+}
+
+func (v validator) hasInterface(node model.NodeID, iface model.InterfaceID, vrf model.VRF) bool {
+	return v.interfaces[interfaceKey{node: node, iface: iface, vrf: vrf}]
+}
+
+func (v validator) hasVRF(node model.NodeID, vrf model.VRF) bool {
+	return v.vrfs[vrfKey{node: node, vrf: vrf}]
+}
+
+type interfaceKey struct {
+	node  model.NodeID
+	iface model.InterfaceID
+	vrf   model.VRF
+}
+
+type vrfKey struct {
+	node model.NodeID
+	vrf  model.VRF
+}

--- a/internal/config/normalized.go
+++ b/internal/config/normalized.go
@@ -41,11 +41,7 @@ func LoadSnapshotDir(path string, topo topology.Topology) (Snapshot, error) {
 			return Snapshot{}, fmt.Errorf("read node config %q: %w", entry.Name(), err)
 		}
 
-		nodeSnapshot, err := ParseNodeConfig(data, topo)
-		if err != nil {
-			return Snapshot{}, fmt.Errorf("parse node config %q: %w", entry.Name(), err)
-		}
-		node, err := nodeSnapshot.singleNode()
+		node, nodeSnapshot, err := parseNodeConfig(data, topo)
 		if err != nil {
 			return Snapshot{}, fmt.Errorf("parse node config %q: %w", entry.Name(), err)
 		}
@@ -71,30 +67,35 @@ func LoadSnapshotDir(path string, topo topology.Topology) (Snapshot, error) {
 }
 
 func ParseNodeConfig(data []byte, topo topology.Topology) (Snapshot, error) {
+	_, snapshot, err := parseNodeConfig(data, topo)
+	return snapshot, err
+}
+
+func parseNodeConfig(data []byte, topo topology.Topology) (model.NodeID, Snapshot, error) {
 	var input nodeConfigYAML
 	if err := yaml.Unmarshal(data, &input); err != nil {
-		return Snapshot{}, fmt.Errorf("parse normalized config: %w", err)
+		return "", Snapshot{}, fmt.Errorf("parse normalized config: %w", err)
 	}
 	if input.Node == "" {
-		return Snapshot{}, fmt.Errorf("node is required")
+		return "", Snapshot{}, fmt.Errorf("node is required")
 	}
 
 	node := model.NodeID(input.Node)
 	validator := newValidator(topo)
 	if !validator.hasNode(node) {
-		return Snapshot{}, fmt.Errorf("node %q not found in topology", node)
+		return "", Snapshot{}, fmt.Errorf("node %q not found in topology", node)
 	}
 
 	var snapshot Snapshot
 	for ifaceName, iface := range input.Interfaces {
 		if ifaceName == "" {
-			return Snapshot{}, fmt.Errorf("interface name must not be empty")
+			return "", Snapshot{}, fmt.Errorf("interface name must not be empty")
 		}
 
 		interfaceID := model.InterfaceID(ifaceName)
 		vrf := defaultVRF(iface.VRF)
 		if !validator.hasInterface(node, interfaceID, vrf) {
-			return Snapshot{}, fmt.Errorf("interface %q in VRF %q on node %q not found in topology", interfaceID, vrf, node)
+			return "", Snapshot{}, fmt.Errorf("interface %q in VRF %q on node %q not found in topology", interfaceID, vrf, node)
 		}
 
 		up := true
@@ -110,7 +111,7 @@ func ParseNodeConfig(data []byte, topo topology.Topology) (Snapshot, error) {
 		for _, rawPrefix := range iface.Addresses {
 			prefix, err := parsePrefix(rawPrefix)
 			if err != nil {
-				return Snapshot{}, fmt.Errorf("interface %q address %q: %w", interfaceID, rawPrefix, err)
+				return "", Snapshot{}, fmt.Errorf("interface %q address %q: %w", interfaceID, rawPrefix, err)
 			}
 			snapshot.InterfaceAddresses = append(snapshot.InterfaceAddresses, model.InterfaceAddress{
 				Node:      node,
@@ -130,16 +131,16 @@ func ParseNodeConfig(data []byte, topo topology.Topology) (Snapshot, error) {
 	for i, route := range input.StaticRoutes {
 		vrf := defaultVRF(route.VRF)
 		if !validator.hasVRF(node, vrf) {
-			return Snapshot{}, fmt.Errorf("VRF %q on node %q not found in topology", vrf, node)
+			return "", Snapshot{}, fmt.Errorf("VRF %q on node %q not found in topology", vrf, node)
 		}
 		prefix, err := parsePrefix(route.Prefix)
 		if err != nil {
-			return Snapshot{}, fmt.Errorf("static route %d prefix %q: %w", i, route.Prefix, err)
+			return "", Snapshot{}, fmt.Errorf("static route %d prefix %q: %w", i, route.Prefix, err)
 		}
 
 		hasNextHop := route.NextHop != ""
 		if hasNextHop == route.Drop {
-			return Snapshot{}, fmt.Errorf("static route %d must specify exactly one of next_hop or drop", i)
+			return "", Snapshot{}, fmt.Errorf("static route %d must specify exactly one of next_hop or drop", i)
 		}
 
 		staticRoute := model.StaticRoute{
@@ -152,7 +153,7 @@ func ParseNodeConfig(data []byte, topo topology.Topology) (Snapshot, error) {
 		} else {
 			nextHop, err := netip.ParseAddr(route.NextHop)
 			if err != nil {
-				return Snapshot{}, fmt.Errorf("static route %d next_hop %q: %w", i, route.NextHop, err)
+				return "", Snapshot{}, fmt.Errorf("static route %d next_hop %q: %w", i, route.NextHop, err)
 			}
 			staticRoute.Action = model.StaticRouteActionNextHop
 			staticRoute.NextHop = nextHop
@@ -161,7 +162,7 @@ func ParseNodeConfig(data []byte, topo topology.Topology) (Snapshot, error) {
 	}
 
 	snapshot.sort()
-	return snapshot, nil
+	return node, snapshot, nil
 }
 
 type nodeConfigYAML struct {
@@ -208,26 +209,6 @@ func (s *Snapshot) append(other Snapshot) {
 	s.InterfaceStates = append(s.InterfaceStates, other.InterfaceStates...)
 	s.ConnectedRoutes = append(s.ConnectedRoutes, other.ConnectedRoutes...)
 	s.StaticRoutes = append(s.StaticRoutes, other.StaticRoutes...)
-}
-
-func (s Snapshot) singleNode() (model.NodeID, error) {
-	nodes := map[model.NodeID]bool{}
-	for _, fact := range s.InterfaceAddresses {
-		nodes[fact.Node] = true
-	}
-	for _, fact := range s.InterfaceStates {
-		nodes[fact.Node] = true
-	}
-	for _, fact := range s.ConnectedRoutes {
-		nodes[fact.Node] = true
-	}
-	for _, fact := range s.StaticRoutes {
-		nodes[fact.Node] = true
-	}
-	for node := range nodes {
-		return node, nil
-	}
-	return "", fmt.Errorf("node config produced no facts")
 }
 
 func (s *Snapshot) sort() {

--- a/internal/config/normalized_test.go
+++ b/internal/config/normalized_test.go
@@ -1,0 +1,313 @@
+package config
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/81ueman/dna/internal/model"
+	"github.com/81ueman/dna/internal/topology"
+)
+
+func TestParseNodeConfig(t *testing.T) {
+	const input = `
+node: r1
+interfaces:
+  Ethernet2:
+    vrf: blue
+    addresses:
+      - 10.0.2.42/24
+  Ethernet1:
+    addresses:
+      - 10.0.12.1/30
+    up: false
+static_routes:
+  - vrf: blue
+    prefix: 10.0.3.42/24
+    next_hop: 10.0.12.2
+  - prefix: 203.0.113.42/24
+    drop: true
+`
+
+	snapshot, err := ParseNodeConfig([]byte(input), testTopology())
+	if err != nil {
+		t.Fatalf("parse node config: %v", err)
+	}
+
+	assertEqual(t, snapshot.InterfaceAddresses, []model.InterfaceAddress{
+		{Node: "r1", Interface: "Ethernet1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30")},
+		{Node: "r1", Interface: "Ethernet2", VRF: "blue", Prefix: mustPrefix(t, "10.0.2.0/24")},
+	})
+	assertEqual(t, snapshot.InterfaceStates, []model.InterfaceState{
+		{Node: "r1", Interface: "Ethernet1", Up: false},
+		{Node: "r1", Interface: "Ethernet2", Up: true},
+	})
+	assertEqual(t, snapshot.ConnectedRoutes, []model.ConnectedRoute{
+		{Node: "r1", VRF: "blue", Prefix: mustPrefix(t, "10.0.2.0/24"), Interface: "Ethernet2"},
+		{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30"), Interface: "Ethernet1"},
+	})
+	assertEqual(t, snapshot.StaticRoutes, []model.StaticRoute{
+		{
+			Node:    "r1",
+			VRF:     "blue",
+			Prefix:  mustPrefix(t, "10.0.3.0/24"),
+			Action:  model.StaticRouteActionNextHop,
+			NextHop: mustAddr(t, "10.0.12.2"),
+		},
+		{
+			Node:   "r1",
+			VRF:    model.DefaultVRF,
+			Prefix: mustPrefix(t, "203.0.113.0/24"),
+			Action: model.StaticRouteActionDrop,
+		},
+	})
+}
+
+func TestLoadSnapshotDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "r2.yml", `
+node: r2
+interfaces:
+  Ethernet1:
+    addresses:
+      - 10.0.12.2/30
+static_routes:
+  - prefix: 10.0.1.0/24
+    next_hop: 10.0.12.1
+`)
+	writeFile(t, dir, "r1.yaml", `
+node: r1
+interfaces:
+  Ethernet1:
+    addresses:
+      - 10.0.12.1/30
+`)
+	writeFile(t, dir, "ignored.txt", `
+not yaml
+`)
+
+	snapshot, err := LoadSnapshotDir(dir, testTopology())
+	if err != nil {
+		t.Fatalf("load snapshot dir: %v", err)
+	}
+
+	assertEqual(t, snapshot.InterfaceAddresses, []model.InterfaceAddress{
+		{Node: "r1", Interface: "Ethernet1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30")},
+		{Node: "r2", Interface: "Ethernet1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30")},
+	})
+	assertEqual(t, snapshot.InterfaceStates, []model.InterfaceState{
+		{Node: "r1", Interface: "Ethernet1", Up: true},
+		{Node: "r2", Interface: "Ethernet1", Up: true},
+	})
+	assertEqual(t, snapshot.ConnectedRoutes, []model.ConnectedRoute{
+		{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30"), Interface: "Ethernet1"},
+		{Node: "r2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30"), Interface: "Ethernet1"},
+	})
+	assertEqual(t, snapshot.StaticRoutes, []model.StaticRoute{
+		{
+			Node:    "r2",
+			VRF:     model.DefaultVRF,
+			Prefix:  mustPrefix(t, "10.0.1.0/24"),
+			Action:  model.StaticRouteActionNextHop,
+			NextHop: mustAddr(t, "10.0.12.1"),
+		},
+	})
+}
+
+func TestLoadSnapshotDirDuplicateNode(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.yaml", `
+node: r1
+interfaces:
+  Ethernet1: {}
+`)
+	writeFile(t, dir, "b.yaml", `
+node: r1
+interfaces:
+  Ethernet1: {}
+`)
+
+	_, err := LoadSnapshotDir(dir, testTopology())
+	if err == nil {
+		t.Fatalf("LoadSnapshotDir succeeded, want duplicate node error")
+	}
+	if !strings.Contains(err.Error(), `duplicate node "r1"`) {
+		t.Fatalf("error = %q, want duplicate node", err)
+	}
+}
+
+func TestParseNodeConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "missing node",
+			input: `
+interfaces:
+  Ethernet1: {}
+`,
+			wantErr: "node is required",
+		},
+		{
+			name: "unknown node",
+			input: `
+node: r3
+interfaces:
+  Ethernet1: {}
+`,
+			wantErr: `node "r3" not found`,
+		},
+		{
+			name: "unknown interface",
+			input: `
+node: r1
+interfaces:
+  Ethernet99: {}
+`,
+			wantErr: `interface "Ethernet99"`,
+		},
+		{
+			name: "unknown interface vrf",
+			input: `
+node: r1
+interfaces:
+  Ethernet2:
+    vrf: default
+`,
+			wantErr: `VRF "default"`,
+		},
+		{
+			name: "unknown static route vrf",
+			input: `
+node: r2
+static_routes:
+  - vrf: blue
+    prefix: 10.0.2.0/24
+    next_hop: 10.0.12.1
+`,
+			wantErr: `VRF "blue"`,
+		},
+		{
+			name: "invalid interface prefix",
+			input: `
+node: r1
+interfaces:
+  Ethernet1:
+    addresses:
+      - not-a-prefix
+`,
+			wantErr: "not-a-prefix",
+		},
+		{
+			name: "invalid static prefix",
+			input: `
+node: r1
+static_routes:
+  - prefix: not-a-prefix
+    next_hop: 10.0.12.2
+`,
+			wantErr: "not-a-prefix",
+		},
+		{
+			name: "invalid next hop",
+			input: `
+node: r1
+static_routes:
+  - prefix: 10.0.2.0/24
+    next_hop: not-an-ip
+`,
+			wantErr: "not-an-ip",
+		},
+		{
+			name: "next hop and drop",
+			input: `
+node: r1
+static_routes:
+  - prefix: 10.0.2.0/24
+    next_hop: 10.0.12.2
+    drop: true
+`,
+			wantErr: "exactly one",
+		},
+		{
+			name: "neither next hop nor drop",
+			input: `
+node: r1
+static_routes:
+  - prefix: 10.0.2.0/24
+`,
+			wantErr: "exactly one",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseNodeConfig([]byte(tt.input), testTopology())
+			if err == nil {
+				t.Fatalf("ParseNodeConfig succeeded, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func testTopology() topology.Topology {
+	return topology.Topology{
+		Nodes: []model.Node{
+			{ID: "r1"},
+			{ID: "r2"},
+		},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "Ethernet1", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "Ethernet2", VRF: "blue"},
+			{Node: "r2", ID: "Ethernet1", VRF: model.DefaultVRF},
+		},
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture %s: %v", name, err)
+	}
+}
+
+func mustPrefix(t *testing.T, raw string) netip.Prefix {
+	t.Helper()
+
+	prefix, err := parsePrefix(raw)
+	if err != nil {
+		t.Fatalf("parse prefix %q: %v", raw, err)
+	}
+	return prefix
+}
+
+func mustAddr(t *testing.T, raw string) netip.Addr {
+	t.Helper()
+
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		t.Fatalf("parse addr %q: %v", raw, err)
+	}
+	return addr
+}
+
+func assertEqual[T comparable](t *testing.T, got, want []T) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d\ngot:  %#v\nwant: %#v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("item %d = %#v, want %#v\ngot:  %#v\nwant: %#v", i, got[i], want[i], got, want)
+		}
+	}
+}

--- a/internal/config/normalized_test.go
+++ b/internal/config/normalized_test.go
@@ -138,6 +138,23 @@ interfaces:
 	}
 }
 
+func TestLoadSnapshotDirMissingTopologyNode(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "r1.yaml", `
+node: r1
+interfaces:
+  Ethernet1: {}
+`)
+
+	_, err := LoadSnapshotDir(dir, testTopology())
+	if err == nil {
+		t.Fatalf("LoadSnapshotDir succeeded, want missing node error")
+	}
+	if !strings.Contains(err.Error(), `missing config for topology node "r2"`) {
+		t.Fatalf("error = %q, want missing topology node", err)
+	}
+}
+
 func TestParseNodeConfigValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/normalized_test.go
+++ b/internal/config/normalized_test.go
@@ -146,6 +146,63 @@ node: r2
 	assertEqual(t, snapshot.StaticRoutes, nil)
 }
 
+func TestLoadSnapshotDirUsesNodeConfigNames(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "leaf1.yaml", `
+node: leaf1
+interfaces:
+  Ethernet1:
+    addresses:
+      - 10.0.12.1/30
+`)
+	writeFile(t, dir, "leaf2.yaml", `
+node: leaf2
+`)
+
+	snapshot, err := LoadSnapshotDir(dir, topologyWithConfigNames())
+	if err != nil {
+		t.Fatalf("load snapshot dir: %v", err)
+	}
+
+	assertEqual(t, snapshot.InterfaceAddresses, []model.InterfaceAddress{
+		{Node: "r1", Interface: "Ethernet1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30")},
+	})
+	assertEqual(t, snapshot.InterfaceStates, []model.InterfaceState{
+		{Node: "r1", Interface: "Ethernet1", Up: true},
+	})
+	assertEqual(t, snapshot.ConnectedRoutes, []model.ConnectedRoute{
+		{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30"), Interface: "Ethernet1"},
+	})
+}
+
+func TestParseNodeConfigUsesNodeConfigName(t *testing.T) {
+	const input = `
+node: leaf1
+interfaces:
+  Ethernet1:
+    addresses:
+      - 10.0.12.1/30
+static_routes:
+  - prefix: 10.0.2.0/24
+    next_hop: 10.0.12.2
+`
+
+	snapshot, err := ParseNodeConfig([]byte(input), topologyWithConfigNames())
+	if err != nil {
+		t.Fatalf("parse node config: %v", err)
+	}
+
+	assertEqual(t, snapshot.StaticRoutes, []model.StaticRoute{
+		{
+			Node:    "r1",
+			VRF:     model.DefaultVRF,
+			Prefix:  mustPrefix(t, "10.0.2.0/24"),
+			Action:  model.StaticRouteActionNextHop,
+			NextHop: mustAddr(t, "10.0.12.2"),
+		},
+	})
+}
+
 func TestLoadSnapshotDirDuplicateNode(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "a.yaml", `
@@ -316,6 +373,15 @@ func testTopology() topology.Topology {
 			{Node: "r2", ID: "Ethernet1", VRF: model.DefaultVRF},
 		},
 	}
+}
+
+func topologyWithConfigNames() topology.Topology {
+	topo := testTopology()
+	topo.NodeConfigNames = map[model.NodeID]string{
+		"r1": "leaf1",
+		"r2": "leaf2",
+	}
+	return topo
 }
 
 func writeFile(t *testing.T, dir, name, content string) {

--- a/internal/config/normalized_test.go
+++ b/internal/config/normalized_test.go
@@ -116,6 +116,36 @@ not yaml
 	})
 }
 
+func TestLoadSnapshotDirAllowsEmptyNodeConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "r1.yaml", `
+node: r1
+interfaces:
+  Ethernet1:
+    addresses:
+      - 10.0.12.1/30
+`)
+	writeFile(t, dir, "r2.yaml", `
+node: r2
+`)
+
+	snapshot, err := LoadSnapshotDir(dir, testTopology())
+	if err != nil {
+		t.Fatalf("load snapshot dir: %v", err)
+	}
+
+	assertEqual(t, snapshot.InterfaceAddresses, []model.InterfaceAddress{
+		{Node: "r1", Interface: "Ethernet1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30")},
+	})
+	assertEqual(t, snapshot.InterfaceStates, []model.InterfaceState{
+		{Node: "r1", Interface: "Ethernet1", Up: true},
+	})
+	assertEqual(t, snapshot.ConnectedRoutes, []model.ConnectedRoute{
+		{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30"), Interface: "Ethernet1"},
+	})
+	assertEqual(t, snapshot.StaticRoutes, nil)
+}
+
 func TestLoadSnapshotDirDuplicateNode(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "a.yaml", `

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -98,18 +98,27 @@ type StaticRoute struct {
 	Node    NodeID
 	VRF     VRF
 	Prefix  netip.Prefix
+	Action  StaticRouteAction
 	NextHop netip.Addr
 }
 
 func (r StaticRoute) String() string {
 	return fmt.Sprintf(
-		"StaticRoute{Node:%s VRF:%s Prefix:%s NextHop:%s}",
+		"StaticRoute{Node:%s VRF:%s Prefix:%s Action:%s NextHop:%s}",
 		r.Node,
 		r.VRF,
 		r.Prefix,
+		r.Action,
 		r.NextHop,
 	)
 }
+
+type StaticRouteAction string
+
+const (
+	StaticRouteActionNextHop StaticRouteAction = "next-hop"
+	StaticRouteActionDrop    StaticRouteAction = "drop"
+)
 
 type ConnectedRoute struct {
 	Node      NodeID

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -69,6 +69,7 @@ func TestComparableFacts(t *testing.T) {
 		Node:    "r1",
 		VRF:     DefaultVRF,
 		Prefix:  mustPrefix(t, "10.0.0.0/24"),
+		Action:  StaticRouteActionNextHop,
 		NextHop: mustAddr(t, "192.0.2.1"),
 	}
 
@@ -138,9 +139,20 @@ func TestFactStrings(t *testing.T) {
 				Node:    "r1",
 				VRF:     DefaultVRF,
 				Prefix:  prefix,
+				Action:  StaticRouteActionNextHop,
 				NextHop: nextHop,
 			}.String(),
-			want: "StaticRoute{Node:r1 VRF:default Prefix:10.0.0.0/24 NextHop:192.0.2.1}",
+			want: "StaticRoute{Node:r1 VRF:default Prefix:10.0.0.0/24 Action:next-hop NextHop:192.0.2.1}",
+		},
+		{
+			name: "drop static route",
+			got: StaticRoute{
+				Node:   "r1",
+				VRF:    DefaultVRF,
+				Prefix: prefix,
+				Action: StaticRouteActionDrop,
+			}.String(),
+			want: "StaticRoute{Node:r1 VRF:default Prefix:10.0.0.0/24 Action:drop NextHop:invalid IP}",
 		},
 		{
 			name: "connected route",


### PR DESCRIPTION
## Summary
- add a normalized per-node YAML snapshot loader for bootstrap config facts
- emit interface addresses, interface states, connected routes, and static routes
- extend static routes with explicit next-hop/drop actions
- validate node, interface, VRF, prefix, next-hop, and duplicate node file errors

Closes #4

## Validation
- go test ./...
- golangci-lint run ./...

## Notes
This PR does not wire the loader into the CLI and does not implement Batfish parsing, forwarding rules, reachability traversal, or the Datalog evaluator.