### PR TITLE
[codex] Build minimal datalog engine

### DIFF
--- a/internal/datalog/database.go
+++ b/internal/datalog/database.go
@@ -1,0 +1,241 @@
+package datalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Database struct {
+	schema    Schema
+	relations map[string]map[string]Row
+}
+
+func NewDatabase(schema Schema) (*Database, error) {
+	if err := validateSchema(schema); err != nil {
+		return nil, err
+	}
+
+	db := &Database{
+		schema:    schema,
+		relations: map[string]map[string]Row{},
+	}
+	for name := range schema.Relations {
+		db.relations[name] = map[string]Row{}
+	}
+	return db, nil
+}
+
+func (db *Database) Schema() Schema {
+	return db.schema
+}
+
+func (db *Database) Insert(relation string, row Row) error {
+	decl, err := db.decl(relation)
+	if err != nil {
+		return err
+	}
+	if err := validateRow(decl, row); err != nil {
+		return fmt.Errorf("insert %s: %w", relation, err)
+	}
+	db.relations[relation][rowKey(row)] = cloneRow(row)
+	return nil
+}
+
+func (db *Database) Delete(relation string, row Row) error {
+	decl, err := db.decl(relation)
+	if err != nil {
+		return err
+	}
+	if err := validateRow(decl, row); err != nil {
+		return fmt.Errorf("delete %s: %w", relation, err)
+	}
+	delete(db.relations[relation], rowKey(row))
+	return nil
+}
+
+func (db *Database) Query(relation string) ([]Row, error) {
+	if _, err := db.decl(relation); err != nil {
+		return nil, err
+	}
+
+	rows := make([]Row, 0, len(db.relations[relation]))
+	for _, row := range db.relations[relation] {
+		rows = append(rows, cloneRow(row))
+	}
+	sortRows(rows)
+	return rows, nil
+}
+
+func (db *Database) Apply(delta Delta) error {
+	for _, change := range delta.Deletes {
+		if err := db.Delete(change.Relation, change.Row); err != nil {
+			return err
+		}
+	}
+	for _, change := range delta.Inserts {
+		if err := db.Insert(change.Relation, change.Row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *Database) Clone() (*Database, error) {
+	clone, err := NewDatabase(db.schema)
+	if err != nil {
+		return nil, err
+	}
+	for relation, rows := range db.relations {
+		for _, row := range rows {
+			clone.relations[relation][rowKey(row)] = cloneRow(row)
+		}
+	}
+	return clone, nil
+}
+
+func (db *Database) Diff(other *Database) (Delta, error) {
+	if err := sameSchema(db.schema, other.schema); err != nil {
+		return Delta{}, err
+	}
+
+	var delta Delta
+	for _, relation := range sortedRelationNames(db.schema) {
+		left := db.relations[relation]
+		right := other.relations[relation]
+		for key, row := range left {
+			if _, ok := right[key]; !ok {
+				delta.Deletes = append(delta.Deletes, RowChange{Relation: relation, Row: cloneRow(row)})
+			}
+		}
+		for key, row := range right {
+			if _, ok := left[key]; !ok {
+				delta.Inserts = append(delta.Inserts, RowChange{Relation: relation, Row: cloneRow(row)})
+			}
+		}
+	}
+	sortChanges(delta.Deletes)
+	sortChanges(delta.Inserts)
+	return delta, nil
+}
+
+func (db *Database) decl(relation string) (RelationDecl, error) {
+	decl, ok := db.schema.Relations[relation]
+	if !ok {
+		return RelationDecl{}, fmt.Errorf("unknown relation %q", relation)
+	}
+	if _, ok := db.relations[relation]; !ok {
+		db.relations[relation] = map[string]Row{}
+	}
+	return decl, nil
+}
+
+func validateSchema(schema Schema) error {
+	if len(schema.Relations) == 0 {
+		return fmt.Errorf("schema must declare at least one relation")
+	}
+	for name, decl := range schema.Relations {
+		if name == "" || decl.Name == "" || name != decl.Name {
+			return fmt.Errorf("invalid relation declaration %q", name)
+		}
+		if len(decl.Fields) == 0 {
+			return fmt.Errorf("relation %q must declare at least one field", name)
+		}
+		seen := map[string]bool{}
+		for _, field := range decl.Fields {
+			if field.Name == "" {
+				return fmt.Errorf("relation %q has an empty field name", name)
+			}
+			if seen[field.Name] {
+				return fmt.Errorf("relation %q declares duplicate field %q", name, field.Name)
+			}
+			seen[field.Name] = true
+			if !validKind(field.Kind) {
+				return fmt.Errorf("relation %q field %q has unsupported type %q", name, field.Name, field.Kind)
+			}
+		}
+	}
+	return nil
+}
+
+func validateRow(decl RelationDecl, row Row) error {
+	if len(row) != len(decl.Fields) {
+		return fmt.Errorf("arity mismatch: got %d values, want %d", len(row), len(decl.Fields))
+	}
+	for i, value := range row {
+		if value.Kind != decl.Fields[i].Kind {
+			return fmt.Errorf("field %q has type %s, got %s", decl.Fields[i].Name, decl.Fields[i].Kind, value.Kind)
+		}
+	}
+	return nil
+}
+
+func sameSchema(left, right Schema) error {
+	if len(left.Relations) != len(right.Relations) {
+		return fmt.Errorf("schema relation count mismatch")
+	}
+	for name, leftDecl := range left.Relations {
+		rightDecl, ok := right.Relations[name]
+		if !ok {
+			return fmt.Errorf("schema missing relation %q", name)
+		}
+		if len(leftDecl.Fields) != len(rightDecl.Fields) {
+			return fmt.Errorf("schema relation %q field count mismatch", name)
+		}
+		for i := range leftDecl.Fields {
+			if leftDecl.Fields[i] != rightDecl.Fields[i] {
+				return fmt.Errorf("schema relation %q field %d mismatch", name, i)
+			}
+		}
+	}
+	return nil
+}
+
+func validKind(kind ValueKind) bool {
+	switch kind {
+	case KindString, KindBool, KindAddr, KindPrefix:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneRow(row Row) Row {
+	clone := make(Row, len(row))
+	copy(clone, row)
+	return clone
+}
+
+func rowKey(row Row) string {
+	var key strings.Builder
+	for _, value := range row {
+		kind := string(value.Kind)
+		data := value.StringValue()
+		fmt.Fprintf(&key, "%d:%s%d:%s", len(kind), kind, len(data), data)
+	}
+	return key.String()
+}
+
+func sortRows(rows []Row) {
+	sort.Slice(rows, func(i, j int) bool {
+		return rowKey(rows[i]) < rowKey(rows[j])
+	})
+}
+
+func sortedRelationNames(schema Schema) []string {
+	names := make([]string, 0, len(schema.Relations))
+	for name := range schema.Relations {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortChanges(changes []RowChange) {
+	sort.Slice(changes, func(i, j int) bool {
+		if changes[i].Relation != changes[j].Relation {
+			return changes[i].Relation < changes[j].Relation
+		}
+		return rowKey(changes[i].Row) < rowKey(changes[j].Row)
+	})
+}

--- a/internal/datalog/database_test.go
+++ b/internal/datalog/database_test.go
@@ -1,0 +1,159 @@
+package datalog
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func testSchema() Schema {
+	return Schema{Relations: map[string]RelationDecl{
+		"Route": {
+			Name: "Route",
+			Fields: []Field{
+				{Name: "node", Kind: KindString},
+				{Name: "up", Kind: KindBool},
+				{Name: "nextHop", Kind: KindAddr},
+				{Name: "prefix", Kind: KindPrefix},
+			},
+		},
+	}}
+}
+
+func testRow() Row {
+	return NewRow(
+		StringValue("r1"),
+		BoolValue(true),
+		AddrValue(netip.MustParseAddr("192.0.2.1")),
+		PrefixValue(netip.MustParsePrefix("10.0.0.42/24")),
+	)
+}
+
+func TestDatabaseInsertDeleteQuery(t *testing.T) {
+	db, err := NewDatabase(testSchema())
+	if err != nil {
+		t.Fatalf("NewDatabase returned error: %v", err)
+	}
+
+	if err := db.Insert("Route", testRow()); err != nil {
+		t.Fatalf("Insert returned error: %v", err)
+	}
+	if err := db.Insert("Route", testRow()); err != nil {
+		t.Fatalf("duplicate Insert returned error: %v", err)
+	}
+
+	rows, err := db.Query("Route")
+	if err != nil {
+		t.Fatalf("Query returned error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if got := rows[0][3].Prefix.String(); got != "10.0.0.0/24" {
+		t.Fatalf("prefix = %s, want masked prefix", got)
+	}
+
+	if err := db.Delete("Route", testRow()); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	rows, err = db.Query("Route")
+	if err != nil {
+		t.Fatalf("Query returned error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("rows after delete = %d, want 0", len(rows))
+	}
+}
+
+func TestDatabaseRejectsTypeMismatch(t *testing.T) {
+	db, err := NewDatabase(testSchema())
+	if err != nil {
+		t.Fatalf("NewDatabase returned error: %v", err)
+	}
+
+	err = db.Insert("Route", NewRow(StringValue("r1")))
+	if err == nil {
+		t.Fatalf("Insert returned nil error for arity mismatch")
+	}
+
+	err = db.Insert("Route", NewRow(
+		StringValue("r1"),
+		StringValue("true"),
+		AddrValue(netip.MustParseAddr("192.0.2.1")),
+		PrefixValue(netip.MustParsePrefix("10.0.0.0/24")),
+	))
+	if err == nil {
+		t.Fatalf("Insert returned nil error for type mismatch")
+	}
+}
+
+func TestDatabaseDiffIsDeterministic(t *testing.T) {
+	left, err := NewDatabase(testSchema())
+	if err != nil {
+		t.Fatalf("NewDatabase left: %v", err)
+	}
+	right, err := NewDatabase(testSchema())
+	if err != nil {
+		t.Fatalf("NewDatabase right: %v", err)
+	}
+
+	row1 := testRow()
+	row2 := NewRow(
+		StringValue("r2"),
+		BoolValue(false),
+		AddrValue(netip.MustParseAddr("192.0.2.2")),
+		PrefixValue(netip.MustParsePrefix("10.0.1.0/24")),
+	)
+	if err := left.Insert("Route", row1); err != nil {
+		t.Fatalf("left insert row1: %v", err)
+	}
+	if err := right.Insert("Route", row2); err != nil {
+		t.Fatalf("right insert row2: %v", err)
+	}
+
+	delta, err := left.Diff(right)
+	if err != nil {
+		t.Fatalf("Diff returned error: %v", err)
+	}
+	if len(delta.Deletes) != 1 || len(delta.Inserts) != 1 {
+		t.Fatalf("delta = %+v, want one delete and one insert", delta)
+	}
+	if got := delta.Deletes[0].Row[0].String; got != "r1" {
+		t.Fatalf("delete row node = %q, want r1", got)
+	}
+	if got := delta.Inserts[0].Row[0].String; got != "r2" {
+		t.Fatalf("insert row node = %q, want r2", got)
+	}
+}
+
+func TestDatabaseRowKeysDistinguishEmbeddedNULStrings(t *testing.T) {
+	schema := Schema{Relations: map[string]RelationDecl{
+		"Pair": {
+			Name: "Pair",
+			Fields: []Field{
+				{Name: "left", Kind: KindString},
+				{Name: "right", Kind: KindString},
+			},
+		},
+	}}
+	db, err := NewDatabase(schema)
+	if err != nil {
+		t.Fatalf("NewDatabase returned error: %v", err)
+	}
+
+	row1 := NewRow(StringValue("x\x00string:y"), StringValue("z"))
+	row2 := NewRow(StringValue("x"), StringValue("y\x00string:z"))
+	if err := db.Insert("Pair", row1); err != nil {
+		t.Fatalf("insert row1: %v", err)
+	}
+	if err := db.Insert("Pair", row2); err != nil {
+		t.Fatalf("insert row2: %v", err)
+	}
+
+	rows, err := db.Query("Pair")
+	if err != nil {
+		t.Fatalf("Query returned error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+}

--- a/internal/datalog/eval.go
+++ b/internal/datalog/eval.go
@@ -1,0 +1,188 @@
+package datalog
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+func Evaluate(program *Program, facts *Database) (*Database, error) {
+	if err := sameSchema(program.Schema, facts.schema); err != nil {
+		return nil, err
+	}
+
+	result, err := NewDatabase(program.Schema)
+	if err != nil {
+		return nil, err
+	}
+	derived := derivedRelations(program)
+	for relation, rows := range facts.relations {
+		if derived[relation] {
+			continue
+		}
+		for _, row := range rows {
+			if err := result.Insert(relation, row); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for _, rule := range program.Rules {
+			rows, err := evalRule(program.Schema, result, rule)
+			if err != nil {
+				return nil, err
+			}
+			for _, row := range rows {
+				before := len(result.relations[rule.Head.Relation])
+				if err := result.Insert(rule.Head.Relation, row); err != nil {
+					return nil, err
+				}
+				if len(result.relations[rule.Head.Relation]) != before {
+					changed = true
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func ApplyDelta(program *Program, current *Database, delta Delta) (*Database, error) {
+	base, err := current.Clone()
+	if err != nil {
+		return nil, err
+	}
+	for relation := range derivedRelations(program) {
+		base.relations[relation] = map[string]Row{}
+	}
+	if err := base.Apply(delta); err != nil {
+		return nil, err
+	}
+	return Evaluate(program, base)
+}
+
+func evalRule(schema Schema, db *Database, rule Rule) ([]Row, error) {
+	bindings := []map[string]Value{{}}
+	for _, atom := range rule.Body {
+		decl := schema.Relations[atom.Relation]
+		rows, err := db.Query(atom.Relation)
+		if err != nil {
+			return nil, err
+		}
+		var next []map[string]Value
+		for _, binding := range bindings {
+			for _, row := range rows {
+				joined, ok, err := matchAtom(decl, atom, row, binding)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					next = append(next, joined)
+				}
+			}
+		}
+		bindings = next
+	}
+
+	headDecl := schema.Relations[rule.Head.Relation]
+	rows := make([]Row, 0, len(bindings))
+	for _, binding := range bindings {
+		row, err := buildHeadRow(headDecl, rule.Head, binding)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	sortRows(rows)
+	return rows, nil
+}
+
+func matchAtom(decl RelationDecl, atom Atom, row Row, binding map[string]Value) (map[string]Value, bool, error) {
+	next := cloneBinding(binding)
+	for i, term := range atom.Terms {
+		value := row[i]
+		if term.IsVariable() {
+			bound, ok := next[term.Variable]
+			if ok {
+				if rowKey(Row{bound}) != rowKey(Row{value}) {
+					return nil, false, nil
+				}
+			} else {
+				next[term.Variable] = value
+			}
+			continue
+		}
+		litValue, err := literalValue(term.Literal, decl.Fields[i].Kind)
+		if err != nil {
+			return nil, false, err
+		}
+		if rowKey(Row{litValue}) != rowKey(Row{value}) {
+			return nil, false, nil
+		}
+	}
+	return next, true, nil
+}
+
+func buildHeadRow(decl RelationDecl, head Atom, binding map[string]Value) (Row, error) {
+	row := make(Row, len(head.Terms))
+	for i, term := range head.Terms {
+		if term.IsVariable() {
+			value, ok := binding[term.Variable]
+			if !ok {
+				return nil, fmt.Errorf("unbound variable %q", term.Variable)
+			}
+			row[i] = value
+			continue
+		}
+		value, err := literalValue(term.Literal, decl.Fields[i].Kind)
+		if err != nil {
+			return nil, err
+		}
+		row[i] = value
+	}
+	return row, nil
+}
+
+func literalValue(lit Literal, kind ValueKind) (Value, error) {
+	if err := literalMatches(lit, kind); err != nil {
+		return Value{}, err
+	}
+	switch kind {
+	case KindString:
+		return StringValue(lit.String), nil
+	case KindBool:
+		return BoolValue(lit.Bool), nil
+	case KindAddr:
+		addr, err := netip.ParseAddr(lit.String)
+		if err != nil {
+			return Value{}, err
+		}
+		return AddrValue(addr), nil
+	case KindPrefix:
+		prefix, err := netip.ParsePrefix(lit.String)
+		if err != nil {
+			return Value{}, err
+		}
+		return PrefixValue(prefix), nil
+	default:
+		return Value{}, fmt.Errorf("unsupported type %s", kind)
+	}
+}
+
+func derivedRelations(program *Program) map[string]bool {
+	derived := map[string]bool{}
+	for _, rule := range program.Rules {
+		derived[rule.Head.Relation] = true
+	}
+	return derived
+}
+
+func cloneBinding(binding map[string]Value) map[string]Value {
+	clone := make(map[string]Value, len(binding))
+	for key, value := range binding {
+		clone[key] = value
+	}
+	return clone
+}

--- a/internal/datalog/eval_test.go
+++ b/internal/datalog/eval_test.go
@@ -1,0 +1,149 @@
+package datalog
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func parseEvalProgram(t *testing.T) *Program {
+	t.Helper()
+
+	program, err := ParseProgram("rules.dna", []byte(`
+		relation StaticRoute(node: string, vrf: string, prefix: prefix, nextHop: addr).
+		relation InterfaceAddress(node: string, vrf: string, nextHop: addr, iface: string).
+		relation Forward(node: string, vrf: string, prefix: prefix, action: string, nextHop: addr, iface: string).
+
+		Forward(node, vrf, prefix, "next-hop", nextHop, "") :-
+			StaticRoute(node, vrf, prefix, nextHop).
+
+		Forward(node, vrf, prefix, "interface", nextHop, iface) :-
+			StaticRoute(node, vrf, prefix, nextHop),
+			InterfaceAddress(node, vrf, nextHop, iface).
+	`))
+	if err != nil {
+		t.Fatalf("ParseProgram returned error: %v", err)
+	}
+	return program
+}
+
+func TestEvaluateStaticRouteProjection(t *testing.T) {
+	program := parseEvalProgram(t)
+	facts, err := NewDatabase(program.Schema)
+	if err != nil {
+		t.Fatalf("NewDatabase returned error: %v", err)
+	}
+	staticRoute := NewRow(
+		StringValue("r1"),
+		StringValue("default"),
+		PrefixValue(netip.MustParsePrefix("10.0.0.0/24")),
+		AddrValue(netip.MustParseAddr("192.0.2.1")),
+	)
+	if err := facts.Insert("StaticRoute", staticRoute); err != nil {
+		t.Fatalf("insert StaticRoute: %v", err)
+	}
+
+	result, err := Evaluate(program, facts)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+
+	rows, err := result.Query("Forward")
+	if err != nil {
+		t.Fatalf("Query Forward: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("Forward rows = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row[0].String != "r1" || row[1].String != "default" || row[3].String != "next-hop" || row[5].String != "" {
+		t.Fatalf("unexpected Forward row: %#v", row)
+	}
+}
+
+func TestEvaluatePositiveJoin(t *testing.T) {
+	program := parseEvalProgram(t)
+	facts, err := NewDatabase(program.Schema)
+	if err != nil {
+		t.Fatalf("NewDatabase returned error: %v", err)
+	}
+	nextHop := netip.MustParseAddr("192.0.2.1")
+	if err := facts.Insert("StaticRoute", NewRow(
+		StringValue("r1"),
+		StringValue("default"),
+		PrefixValue(netip.MustParsePrefix("10.0.0.0/24")),
+		AddrValue(nextHop),
+	)); err != nil {
+		t.Fatalf("insert StaticRoute: %v", err)
+	}
+	if err := facts.Insert("InterfaceAddress", NewRow(
+		StringValue("r1"),
+		StringValue("default"),
+		AddrValue(nextHop),
+		StringValue("Ethernet1"),
+	)); err != nil {
+		t.Fatalf("insert InterfaceAddress: %v", err)
+	}
+
+	result, err := Evaluate(program, facts)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	rows, err := result.Query("Forward")
+	if err != nil {
+		t.Fatalf("Query Forward: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("Forward rows = %d, want 2", len(rows))
+	}
+	actions := map[string]bool{}
+	for _, row := range rows {
+		actions[row[3].String] = true
+	}
+	if !actions["interface"] || !actions["next-hop"] {
+		t.Fatalf("actions = %#v, want interface and next-hop", actions)
+	}
+}
+
+func TestApplyDeltaMatchesFullRecompute(t *testing.T) {
+	program := parseEvalProgram(t)
+	facts, err := NewDatabase(program.Schema)
+	if err != nil {
+		t.Fatalf("NewDatabase facts: %v", err)
+	}
+	row := NewRow(
+		StringValue("r1"),
+		StringValue("default"),
+		PrefixValue(netip.MustParsePrefix("10.0.0.0/24")),
+		AddrValue(netip.MustParseAddr("192.0.2.1")),
+	)
+	if err := facts.Insert("StaticRoute", row); err != nil {
+		t.Fatalf("insert StaticRoute: %v", err)
+	}
+	current, err := Evaluate(program, facts)
+	if err != nil {
+		t.Fatalf("Evaluate current: %v", err)
+	}
+
+	delta := Delta{Deletes: []RowChange{{Relation: "StaticRoute", Row: row}}}
+	incremental, err := ApplyDelta(program, current, delta)
+	if err != nil {
+		t.Fatalf("ApplyDelta returned error: %v", err)
+	}
+
+	updatedFacts, err := NewDatabase(program.Schema)
+	if err != nil {
+		t.Fatalf("NewDatabase updatedFacts: %v", err)
+	}
+	full, err := Evaluate(program, updatedFacts)
+	if err != nil {
+		t.Fatalf("Evaluate full: %v", err)
+	}
+
+	diff, err := incremental.Diff(full)
+	if err != nil {
+		t.Fatalf("Diff returned error: %v", err)
+	}
+	if len(diff.Inserts) != 0 || len(diff.Deletes) != 0 {
+		t.Fatalf("incremental/full diff = %+v, want empty", diff)
+	}
+}

--- a/internal/datalog/parser.go
+++ b/internal/datalog/parser.go
@@ -1,0 +1,527 @@
+package datalog
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+	"unicode"
+)
+
+func ParseProgram(name string, src []byte) (*Program, error) {
+	_ = name
+
+	statements, err := splitStatements(stripComments(string(src)))
+	if err != nil {
+		return nil, err
+	}
+
+	program := &Program{Schema: Schema{Relations: map[string]RelationDecl{}}}
+	for _, stmt := range statements {
+		switch {
+		case strings.HasPrefix(stmt, "relation "):
+			decl, err := parseRelationDecl(stmt)
+			if err != nil {
+				return nil, err
+			}
+			if _, exists := program.Schema.Relations[decl.Name]; exists {
+				return nil, fmt.Errorf("duplicate relation %q", decl.Name)
+			}
+			program.Schema.Relations[decl.Name] = decl
+		case strings.Contains(stmt, ":-"):
+			rule, err := parseRule(stmt)
+			if err != nil {
+				return nil, err
+			}
+			program.Rules = append(program.Rules, rule)
+		default:
+			return nil, fmt.Errorf("unsupported statement %q", stmt)
+		}
+	}
+	if err := validateSchema(program.Schema); err != nil {
+		return nil, err
+	}
+	if err := validateProgram(program); err != nil {
+		return nil, err
+	}
+	return program, nil
+}
+
+func stripComments(src string) string {
+	var out strings.Builder
+	inString := false
+	for _, line := range strings.Split(src, "\n") {
+		inString = false
+		for i, r := range line {
+			if r == '"' && (i == 0 || line[i-1] != '\\') {
+				inString = !inString
+			}
+			if r == '#' && !inString {
+				break
+			}
+			out.WriteRune(r)
+		}
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+func splitStatements(src string) ([]string, error) {
+	var statements []string
+	var current strings.Builder
+	inString := false
+	escaped := false
+	for _, r := range src {
+		if inString {
+			current.WriteRune(r)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch r {
+		case '"':
+			inString = true
+			current.WriteRune(r)
+		case '.':
+			stmt := strings.TrimSpace(current.String())
+			if stmt != "" {
+				statements = append(statements, stmt)
+			}
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if inString {
+		return nil, fmt.Errorf("unterminated string literal")
+	}
+	if tail := strings.TrimSpace(current.String()); tail != "" {
+		return nil, fmt.Errorf("statement missing trailing period: %q", tail)
+	}
+	return statements, nil
+}
+
+func parseRelationDecl(stmt string) (RelationDecl, error) {
+	rest := strings.TrimSpace(strings.TrimPrefix(stmt, "relation "))
+	name, args, err := parseCall(rest)
+	if err != nil {
+		return RelationDecl{}, fmt.Errorf("parse relation declaration: %w", err)
+	}
+	if !isIdent(name) {
+		return RelationDecl{}, fmt.Errorf("invalid relation name %q", name)
+	}
+
+	decl := RelationDecl{Name: name}
+	for _, arg := range args {
+		fieldName, rawType, ok := strings.Cut(arg, ":")
+		if !ok {
+			return RelationDecl{}, fmt.Errorf("relation %q field %q must use name: type", name, arg)
+		}
+		fieldName = strings.TrimSpace(fieldName)
+		rawType = strings.TrimSpace(rawType)
+		if !isIdent(fieldName) {
+			return RelationDecl{}, fmt.Errorf("relation %q has invalid field name %q", name, fieldName)
+		}
+		kind := ValueKind(rawType)
+		if !validKind(kind) {
+			return RelationDecl{}, fmt.Errorf("relation %q field %q has unsupported type %q", name, fieldName, rawType)
+		}
+		decl.Fields = append(decl.Fields, Field{Name: fieldName, Kind: kind})
+	}
+	return decl, nil
+}
+
+func parseRule(stmt string) (Rule, error) {
+	outsideStrings, err := outsideStringText(stmt)
+	if err != nil {
+		return Rule{}, err
+	}
+	if strings.Contains(outsideStrings, "!") || containsWord(outsideStrings, "not") {
+		return Rule{}, fmt.Errorf("unsupported negation in rule %q", stmt)
+	}
+	lower := strings.ToLower(outsideStrings)
+	if strings.Contains(lower, "aggregate") || strings.Contains(lower, "group<") {
+		return Rule{}, fmt.Errorf("unsupported aggregation in rule %q", stmt)
+	}
+	headRaw, bodyRaw, ok := cutRuleSeparator(stmt)
+	if !ok {
+		return Rule{}, fmt.Errorf("rule missing :-")
+	}
+	head, err := parseAtom(strings.TrimSpace(headRaw))
+	if err != nil {
+		return Rule{}, fmt.Errorf("parse rule head: %w", err)
+	}
+	bodyParts, err := splitTopLevel(bodyRaw, ',')
+	if err != nil {
+		return Rule{}, err
+	}
+	if len(bodyParts) == 0 {
+		return Rule{}, fmt.Errorf("rule body must contain at least one atom")
+	}
+	rule := Rule{Head: head}
+	for _, part := range bodyParts {
+		atom, err := parseAtom(strings.TrimSpace(part))
+		if err != nil {
+			return Rule{}, fmt.Errorf("parse rule body: %w", err)
+		}
+		rule.Body = append(rule.Body, atom)
+	}
+	return rule, nil
+}
+
+func parseAtom(raw string) (Atom, error) {
+	name, args, err := parseCall(raw)
+	if err != nil {
+		return Atom{}, err
+	}
+	if !isIdent(name) {
+		return Atom{}, fmt.Errorf("invalid relation name %q", name)
+	}
+	atom := Atom{Relation: name}
+	for _, arg := range args {
+		term, err := parseTerm(arg)
+		if err != nil {
+			return Atom{}, err
+		}
+		atom.Terms = append(atom.Terms, term)
+	}
+	return atom, nil
+}
+
+func parseCall(raw string) (string, []string, error) {
+	open := strings.IndexRune(raw, '(')
+	close := strings.LastIndex(raw, ")")
+	if open < 0 || close != len(raw)-1 || close < open {
+		return "", nil, fmt.Errorf("%q must be in Name(...) form", raw)
+	}
+	name := strings.TrimSpace(raw[:open])
+	body := strings.TrimSpace(raw[open+1 : close])
+	if body == "" {
+		return name, nil, nil
+	}
+	args, err := splitTopLevel(body, ',')
+	if err != nil {
+		return "", nil, err
+	}
+	return name, args, nil
+}
+
+func parseTerm(raw string) (Term, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Term{}, fmt.Errorf("empty term")
+	}
+	if raw == "_" {
+		return Term{}, fmt.Errorf("unsupported anonymous variable")
+	}
+	if raw == "true" {
+		return BoolLit(true), nil
+	}
+	if raw == "false" {
+		return BoolLit(false), nil
+	}
+	if strings.HasPrefix(raw, "\"") {
+		if !strings.HasSuffix(raw, "\"") || len(raw) < 2 {
+			return Term{}, fmt.Errorf("unterminated string literal %q", raw)
+		}
+		return StringLit(strings.ReplaceAll(raw[1:len(raw)-1], `\"`, `"`)), nil
+	}
+	if !isIdent(raw) {
+		return Term{}, fmt.Errorf("unsupported term %q", raw)
+	}
+	return Var(raw), nil
+}
+
+func outsideStringText(raw string) (string, error) {
+	var out strings.Builder
+	inString := false
+	escaped := false
+	for _, r := range raw {
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inString = false
+			}
+			continue
+		}
+		if r == '"' {
+			inString = true
+			continue
+		}
+		out.WriteRune(r)
+	}
+	if inString {
+		return "", fmt.Errorf("unterminated string literal")
+	}
+	return out.String(), nil
+}
+
+func cutRuleSeparator(raw string) (string, string, bool) {
+	inString := false
+	escaped := false
+	for i, r := range raw {
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inString = false
+			}
+			continue
+		}
+		if r == '"' {
+			inString = true
+			continue
+		}
+		if r == ':' && strings.HasPrefix(raw[i:], ":-") {
+			return raw[:i], raw[i+2:], true
+		}
+	}
+	return "", "", false
+}
+
+func containsWord(raw, word string) bool {
+	for start := 0; start <= len(raw)-len(word); start++ {
+		if raw[start:start+len(word)] != word {
+			continue
+		}
+		beforeOK := start == 0 || !isIdentRune(rune(raw[start-1]))
+		after := start + len(word)
+		afterOK := after == len(raw) || !isIdentRune(rune(raw[after]))
+		if beforeOK && afterOK {
+			return true
+		}
+	}
+	return false
+}
+
+func splitTopLevel(raw string, sep rune) ([]string, error) {
+	var parts []string
+	var current strings.Builder
+	depth := 0
+	inString := false
+	escaped := false
+	for _, r := range raw {
+		if inString {
+			current.WriteRune(r)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch r {
+		case '"':
+			inString = true
+			current.WriteRune(r)
+		case '(':
+			depth++
+			current.WriteRune(r)
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, fmt.Errorf("unbalanced parentheses")
+			}
+			current.WriteRune(r)
+		default:
+			if r == sep && depth == 0 {
+				part := strings.TrimSpace(current.String())
+				if part == "" {
+					return nil, fmt.Errorf("empty list element")
+				}
+				parts = append(parts, part)
+				current.Reset()
+				continue
+			}
+			current.WriteRune(r)
+		}
+	}
+	if inString {
+		return nil, fmt.Errorf("unterminated string literal")
+	}
+	if depth != 0 {
+		return nil, fmt.Errorf("unbalanced parentheses")
+	}
+	part := strings.TrimSpace(current.String())
+	if part == "" {
+		return nil, fmt.Errorf("empty list element")
+	}
+	parts = append(parts, part)
+	return parts, nil
+}
+
+func validateProgram(program *Program) error {
+	for _, rule := range program.Rules {
+		if err := validateAtom(program.Schema, rule.Head); err != nil {
+			return fmt.Errorf("head %s: %w", rule.Head.Relation, err)
+		}
+		bodyVars := map[string]ValueKind{}
+		for _, atom := range rule.Body {
+			if err := validateAtom(program.Schema, atom); err != nil {
+				return fmt.Errorf("body %s: %w", atom.Relation, err)
+			}
+			decl := program.Schema.Relations[atom.Relation]
+			for i, term := range atom.Terms {
+				kind := decl.Fields[i].Kind
+				if term.IsVariable() {
+					if previous, ok := bodyVars[term.Variable]; ok && previous != kind {
+						return fmt.Errorf("variable %q used with both %s and %s", term.Variable, previous, kind)
+					}
+					bodyVars[term.Variable] = kind
+					continue
+				}
+				if err := literalMatches(term.Literal, kind); err != nil {
+					return fmt.Errorf("body %s term %d: %w", atom.Relation, i, err)
+				}
+			}
+		}
+
+		headDecl := program.Schema.Relations[rule.Head.Relation]
+		for i, term := range rule.Head.Terms {
+			kind := headDecl.Fields[i].Kind
+			if term.IsVariable() {
+				bodyKind, ok := bodyVars[term.Variable]
+				if !ok {
+					return fmt.Errorf("head variable %q is not bound by rule body", term.Variable)
+				}
+				if bodyKind != kind {
+					return fmt.Errorf("head variable %q has type %s, target field requires %s", term.Variable, bodyKind, kind)
+				}
+				continue
+			}
+			if err := literalMatches(term.Literal, kind); err != nil {
+				return fmt.Errorf("head %s term %d: %w", rule.Head.Relation, i, err)
+			}
+		}
+	}
+	return validateAcyclicRules(program)
+}
+
+func validateAtom(schema Schema, atom Atom) error {
+	decl, ok := schema.Relations[atom.Relation]
+	if !ok {
+		return fmt.Errorf("unknown relation %q", atom.Relation)
+	}
+	if len(atom.Terms) != len(decl.Fields) {
+		return fmt.Errorf("arity mismatch: got %d terms, want %d", len(atom.Terms), len(decl.Fields))
+	}
+	return nil
+}
+
+func literalMatches(lit Literal, kind ValueKind) error {
+	if !lit.Set {
+		return fmt.Errorf("missing literal")
+	}
+	switch kind {
+	case KindString:
+		if lit.Kind != KindString {
+			return fmt.Errorf("literal has type %s, want %s", lit.Kind, kind)
+		}
+	case KindBool:
+		if lit.Kind != KindBool {
+			return fmt.Errorf("literal has type %s, want %s", lit.Kind, kind)
+		}
+	case KindAddr:
+		if lit.Kind != KindString {
+			return fmt.Errorf("addr literal must be quoted")
+		}
+		if _, err := netip.ParseAddr(lit.String); err != nil {
+			return fmt.Errorf("invalid addr literal %q", lit.String)
+		}
+	case KindPrefix:
+		if lit.Kind != KindString {
+			return fmt.Errorf("prefix literal must be quoted")
+		}
+		if _, err := netip.ParsePrefix(lit.String); err != nil {
+			return fmt.Errorf("invalid prefix literal %q", lit.String)
+		}
+	default:
+		return fmt.Errorf("unsupported type %s", kind)
+	}
+	return nil
+}
+
+func validateAcyclicRules(program *Program) error {
+	graph := map[string][]string{}
+	for _, rule := range program.Rules {
+		for _, atom := range rule.Body {
+			graph[rule.Head.Relation] = append(graph[rule.Head.Relation], atom.Relation)
+		}
+	}
+
+	visiting := map[string]bool{}
+	visited := map[string]bool{}
+	var visit func(string) error
+	visit = func(relation string) error {
+		if visiting[relation] {
+			return fmt.Errorf("unsupported recursive rule involving %q", relation)
+		}
+		if visited[relation] {
+			return nil
+		}
+		visiting[relation] = true
+		for _, dep := range graph[relation] {
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		visiting[relation] = false
+		visited[relation] = true
+		return nil
+	}
+	for relation := range graph {
+		if err := visit(relation); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isIdent(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	for i, r := range raw {
+		if i == 0 {
+			if !unicode.IsLetter(r) && r != '_' {
+				return false
+			}
+			continue
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func isIdentRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}

--- a/internal/datalog/parser_test.go
+++ b/internal/datalog/parser_test.go
@@ -1,0 +1,150 @@
+package datalog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseProgram(t *testing.T) {
+	src := []byte(`
+		# static routes become forwarding rows
+		relation StaticRoute(node: string, vrf: string, prefix: prefix, nextHop: addr).
+		relation Forward(node: string, vrf: string, prefix: prefix, action: string, nextHop: addr, iface: string).
+
+		Forward(node, vrf, prefix, "next-hop", nextHop, "") :-
+			StaticRoute(node, vrf, prefix, nextHop).
+	`)
+
+	program, err := ParseProgram("rules.dna", src)
+	if err != nil {
+		t.Fatalf("ParseProgram returned error: %v", err)
+	}
+
+	if len(program.Schema.Relations) != 2 {
+		t.Fatalf("relations = %d, want 2", len(program.Schema.Relations))
+	}
+	if len(program.Rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(program.Rules))
+	}
+	if got := program.Rules[0].Head.Relation; got != "Forward" {
+		t.Fatalf("head relation = %q, want Forward", got)
+	}
+}
+
+func TestParseProgramAllowsNegationTextInsideStringLiterals(t *testing.T) {
+	src := []byte(`
+		relation Input(node: string).
+		relation Action(node: string, label: string, note: string).
+
+		Action(node, "drop!", "do not alarm") :-
+			Input(node).
+	`)
+
+	program, err := ParseProgram("rules.dna", src)
+	if err != nil {
+		t.Fatalf("ParseProgram returned error: %v", err)
+	}
+	if len(program.Rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(program.Rules))
+	}
+}
+
+func TestParseProgramCutsRuleSeparatorOutsideStringLiterals(t *testing.T) {
+	src := []byte(`
+		relation Input(node: string).
+		relation Action(node: string, label: string).
+
+		Action(node, "x:-y") :-
+			Input(node).
+	`)
+
+	program, err := ParseProgram("rules.dna", src)
+	if err != nil {
+		t.Fatalf("ParseProgram returned error: %v", err)
+	}
+	if got := program.Rules[0].Head.Terms[1].Literal.String; got != "x:-y" {
+		t.Fatalf("head literal = %q, want x:-y", got)
+	}
+}
+
+func TestParseProgramRejectsUnsupportedFeatures(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "negation",
+			src: `
+				relation A(x: string).
+				relation B(x: string).
+				B(x) :- not A(x).
+			`,
+			want: "unsupported negation",
+		},
+		{
+			name: "aggregation",
+			src: `
+				relation A(x: string).
+				relation B(x: string).
+				B(x) :- Aggregate(A(x)).
+			`,
+			want: "unsupported aggregation",
+		},
+		{
+			name: "recursion",
+			src: `
+				relation A(x: string).
+				A(x) :- A(x).
+			`,
+			want: "unsupported recursive rule",
+		},
+		{
+			name: "unknown relation",
+			src: `
+				relation A(x: string).
+				A(x) :- Missing(x).
+			`,
+			want: "unknown relation",
+		},
+		{
+			name: "arity mismatch",
+			src: `
+				relation A(x: string).
+				relation B(x: string).
+				B(x) :- A(x, y).
+			`,
+			want: "arity mismatch",
+		},
+		{
+			name: "type mismatch",
+			src: `
+				relation A(x: string).
+				relation B(x: bool).
+				B(x) :- A(x).
+			`,
+			want: "target field requires bool",
+		},
+		{
+			name: "anonymous variable",
+			src: `
+				relation A(x: string).
+				relation B(x: string).
+				B(x) :- A(_).
+			`,
+			want: "unsupported anonymous variable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseProgram("bad.dna", []byte(tt.src))
+			if err == nil {
+				t.Fatalf("ParseProgram returned nil error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/datalog/types.go
+++ b/internal/datalog/types.go
@@ -1,0 +1,129 @@
+package datalog
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+type ValueKind string
+
+const (
+	KindString ValueKind = "string"
+	KindBool   ValueKind = "bool"
+	KindAddr   ValueKind = "addr"
+	KindPrefix ValueKind = "prefix"
+)
+
+type Field struct {
+	Name string
+	Kind ValueKind
+}
+
+type RelationDecl struct {
+	Name   string
+	Fields []Field
+}
+
+type Schema struct {
+	Relations map[string]RelationDecl
+}
+
+type Program struct {
+	Schema Schema
+	Rules  []Rule
+}
+
+type Rule struct {
+	Head Atom
+	Body []Atom
+}
+
+type Atom struct {
+	Relation string
+	Terms    []Term
+}
+
+type Term struct {
+	Variable string
+	Literal  Literal
+}
+
+func Var(name string) Term {
+	return Term{Variable: name}
+}
+
+func StringLit(value string) Term {
+	return Term{Literal: Literal{Kind: KindString, String: value, Set: true}}
+}
+
+func BoolLit(value bool) Term {
+	return Term{Literal: Literal{Kind: KindBool, Bool: value, Set: true}}
+}
+
+func (t Term) IsVariable() bool {
+	return t.Variable != ""
+}
+
+type Literal struct {
+	Kind   ValueKind
+	String string
+	Bool   bool
+	Set    bool
+}
+
+type Value struct {
+	Kind   ValueKind
+	String string
+	Bool   bool
+	Addr   netip.Addr
+	Prefix netip.Prefix
+}
+
+func StringValue(value string) Value {
+	return Value{Kind: KindString, String: value}
+}
+
+func BoolValue(value bool) Value {
+	return Value{Kind: KindBool, Bool: value}
+}
+
+func AddrValue(value netip.Addr) Value {
+	return Value{Kind: KindAddr, Addr: value}
+}
+
+func PrefixValue(value netip.Prefix) Value {
+	return Value{Kind: KindPrefix, Prefix: value.Masked()}
+}
+
+func (v Value) StringValue() string {
+	switch v.Kind {
+	case KindString:
+		return v.String
+	case KindBool:
+		return fmt.Sprintf("%t", v.Bool)
+	case KindAddr:
+		return v.Addr.String()
+	case KindPrefix:
+		return v.Prefix.String()
+	default:
+		return "<invalid>"
+	}
+}
+
+type Row []Value
+
+func NewRow(values ...Value) Row {
+	row := make(Row, len(values))
+	copy(row, values)
+	return row
+}
+
+type RowChange struct {
+	Relation string
+	Row      Row
+}
+
+type Delta struct {
+	Inserts []RowChange
+	Deletes []RowChange
+}


### PR DESCRIPTION
## Summary
- Add an internal DNA-specific datalog package for relation declarations, typed rows, deltas, and deterministic diffs.
- Implement a narrow `.dna` parser and positive-rule evaluator for projection and join rules.
- Document unsupported DDlog features with tests, including negation, aggregation, recursion, arity/type mismatches, and anonymous variables.

## Validation
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`

Closes #3.