### PR TITLE
[codex] Derive static and connected forwarding rules

### DIFF
--- a/internal/config/normalized.go
+++ b/internal/config/normalized.go
@@ -119,12 +119,14 @@ func parseNodeConfig(data []byte, topo topology.Topology) (model.NodeID, Snapsho
 				VRF:       vrf,
 				Prefix:    prefix,
 			})
-			snapshot.ConnectedRoutes = append(snapshot.ConnectedRoutes, model.ConnectedRoute{
-				Node:      node,
-				VRF:       vrf,
-				Prefix:    prefix,
-				Interface: interfaceID,
-			})
+			if up {
+				snapshot.ConnectedRoutes = append(snapshot.ConnectedRoutes, model.ConnectedRoute{
+					Node:      node,
+					VRF:       vrf,
+					Prefix:    prefix,
+					Interface: interfaceID,
+				})
+			}
 		}
 	}
 

--- a/internal/config/normalized_test.go
+++ b/internal/config/normalized_test.go
@@ -46,7 +46,6 @@ static_routes:
 	})
 	assertEqual(t, snapshot.ConnectedRoutes, []model.ConnectedRoute{
 		{Node: "r1", VRF: "blue", Prefix: mustPrefix(t, "10.0.2.0/24"), Interface: "Ethernet2"},
-		{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.12.0/30"), Interface: "Ethernet1"},
 	})
 	assertEqual(t, snapshot.StaticRoutes, []model.StaticRoute{
 		{

--- a/internal/forwarding/forwarding.go
+++ b/internal/forwarding/forwarding.go
@@ -1,0 +1,181 @@
+package forwarding
+
+import (
+	"net/netip"
+	"sort"
+
+	"github.com/81ueman/dna/internal/model"
+)
+
+// ConnectedRoutes derives connected routes only for interfaces that are up.
+// Interfaces without an explicit state are treated as up so tests and adapters
+// can pass partial fact sets.
+func ConnectedRoutes(
+	addresses []model.InterfaceAddress,
+	states []model.InterfaceState,
+) []model.ConnectedRoute {
+	up := map[interfaceKey]bool{}
+	for _, state := range states {
+		up[interfaceKey{node: state.Node, iface: state.Interface}] = state.Up
+	}
+
+	seen := map[model.ConnectedRoute]bool{}
+	var routes []model.ConnectedRoute
+	for _, address := range addresses {
+		if stateUp, ok := up[interfaceKey{node: address.Node, iface: address.Interface}]; ok && !stateUp {
+			continue
+		}
+
+		route := model.ConnectedRoute{
+			Node:      address.Node,
+			VRF:       address.VRF,
+			Prefix:    address.Prefix.Masked(),
+			Interface: address.Interface,
+		}
+		if seen[route] {
+			continue
+		}
+		seen[route] = true
+		routes = append(routes, route)
+	}
+
+	sortConnectedRoutes(routes)
+	return routes
+}
+
+func Rules(
+	staticRoutes []model.StaticRoute,
+	connectedRoutes []model.ConnectedRoute,
+) []model.ForwardingRule {
+	seen := map[model.ForwardingRule]bool{}
+	var rules []model.ForwardingRule
+
+	for _, route := range connectedRoutes {
+		rule := model.ForwardingRule{
+			Node:      route.Node,
+			VRF:       route.VRF,
+			Prefix:    route.Prefix.Masked(),
+			Action:    model.ForwardActionInterface,
+			Interface: route.Interface,
+		}
+		if seen[rule] {
+			continue
+		}
+		seen[rule] = true
+		rules = append(rules, rule)
+	}
+
+	for _, route := range staticRoutes {
+		rule := model.ForwardingRule{
+			Node:   route.Node,
+			VRF:    route.VRF,
+			Prefix: route.Prefix.Masked(),
+		}
+		switch route.Action {
+		case model.StaticRouteActionDrop:
+			rule.Action = model.ForwardActionDrop
+		default:
+			rule.Action = model.ForwardActionNextHop
+			rule.NextHop = route.NextHop
+		}
+		if seen[rule] {
+			continue
+		}
+		seen[rule] = true
+		rules = append(rules, rule)
+	}
+
+	sortRules(rules)
+	return rules
+}
+
+func RulesFromFacts(
+	addresses []model.InterfaceAddress,
+	states []model.InterfaceState,
+	staticRoutes []model.StaticRoute,
+) []model.ForwardingRule {
+	return Rules(staticRoutes, ConnectedRoutes(addresses, states))
+}
+
+func Lookup(
+	rules []model.ForwardingRule,
+	node model.NodeID,
+	vrf model.VRF,
+	destination netip.Addr,
+) []model.ForwardingRule {
+	bestBits := -1
+	var matches []model.ForwardingRule
+	for _, rule := range rules {
+		if rule.Node != node || rule.VRF != vrf || !rule.Prefix.Contains(destination) {
+			continue
+		}
+		bits := rule.Prefix.Bits()
+		if bits < bestBits {
+			continue
+		}
+		if bits > bestBits {
+			bestBits = bits
+			matches = matches[:0]
+		}
+		matches = append(matches, rule)
+	}
+
+	sortRules(matches)
+	return matches
+}
+
+type interfaceKey struct {
+	node  model.NodeID
+	iface model.InterfaceID
+}
+
+func sortConnectedRoutes(routes []model.ConnectedRoute) {
+	sort.Slice(routes, func(i, j int) bool {
+		a, b := routes[i], routes[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		if comparePrefix(a.Prefix, b.Prefix) != 0 {
+			return comparePrefix(a.Prefix, b.Prefix) < 0
+		}
+		return a.Interface < b.Interface
+	})
+}
+
+func sortRules(rules []model.ForwardingRule) {
+	sort.Slice(rules, func(i, j int) bool {
+		a, b := rules[i], rules[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		if comparePrefix(a.Prefix, b.Prefix) != 0 {
+			return comparePrefix(a.Prefix, b.Prefix) < 0
+		}
+		if a.Action != b.Action {
+			return a.Action < b.Action
+		}
+		if a.NextHop.Compare(b.NextHop) != 0 {
+			return a.NextHop.Compare(b.NextHop) < 0
+		}
+		return a.Interface < b.Interface
+	})
+}
+
+func comparePrefix(a, b netip.Prefix) int {
+	if cmp := a.Addr().Compare(b.Addr()); cmp != 0 {
+		return cmp
+	}
+	if a.Bits() < b.Bits() {
+		return -1
+	}
+	if a.Bits() > b.Bits() {
+		return 1
+	}
+	return 0
+}

--- a/internal/forwarding/forwarding_test.go
+++ b/internal/forwarding/forwarding_test.go
@@ -1,0 +1,185 @@
+package forwarding
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/81ueman/dna/internal/model"
+)
+
+func TestConnectedRoutesSuppressDisabledInterfaces(t *testing.T) {
+	routes := ConnectedRoutes(
+		[]model.InterfaceAddress{
+			{Node: "r1", Interface: "Ethernet1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.1.1/24")},
+			{Node: "r1", Interface: "Ethernet2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.1/24")},
+		},
+		[]model.InterfaceState{
+			{Node: "r1", Interface: "Ethernet1", Up: false},
+			{Node: "r1", Interface: "Ethernet2", Up: true},
+		},
+	)
+
+	assertEqual(t, routes, []model.ConnectedRoute{
+		{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.0/24"), Interface: "Ethernet2"},
+	})
+}
+
+func TestRulesFromStaticAndConnectedRoutes(t *testing.T) {
+	rules := Rules(
+		[]model.StaticRoute{
+			{
+				Node:    "r1",
+				VRF:     model.DefaultVRF,
+				Prefix:  mustPrefix(t, "10.0.3.0/24"),
+				Action:  model.StaticRouteActionNextHop,
+				NextHop: mustAddr(t, "192.0.2.1"),
+			},
+			{
+				Node:   "r1",
+				VRF:    "blue",
+				Prefix: mustPrefix(t, "203.0.113.0/24"),
+				Action: model.StaticRouteActionDrop,
+			},
+		},
+		[]model.ConnectedRoute{
+			{Node: "r1", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.1.0/24"), Interface: "Ethernet1"},
+		},
+	)
+
+	assertEqual(t, rules, []model.ForwardingRule{
+		{
+			Node:   "r1",
+			VRF:    "blue",
+			Prefix: mustPrefix(t, "203.0.113.0/24"),
+			Action: model.ForwardActionDrop,
+		},
+		{
+			Node:      "r1",
+			VRF:       model.DefaultVRF,
+			Prefix:    mustPrefix(t, "10.0.1.0/24"),
+			Action:    model.ForwardActionInterface,
+			Interface: "Ethernet1",
+		},
+		{
+			Node:    "r1",
+			VRF:     model.DefaultVRF,
+			Prefix:  mustPrefix(t, "10.0.3.0/24"),
+			Action:  model.ForwardActionNextHop,
+			NextHop: mustAddr(t, "192.0.2.1"),
+		},
+	})
+}
+
+func TestLookupUsesLongestPrefixMatch(t *testing.T) {
+	rules := []model.ForwardingRule{
+		{
+			Node:    "r1",
+			VRF:     model.DefaultVRF,
+			Prefix:  mustPrefix(t, "10.0.0.0/16"),
+			Action:  model.ForwardActionNextHop,
+			NextHop: mustAddr(t, "192.0.2.1"),
+		},
+		{
+			Node:      "r1",
+			VRF:       model.DefaultVRF,
+			Prefix:    mustPrefix(t, "10.0.1.0/24"),
+			Action:    model.ForwardActionInterface,
+			Interface: "Ethernet1",
+		},
+		{
+			Node:    "r1",
+			VRF:     "blue",
+			Prefix:  mustPrefix(t, "10.0.1.0/24"),
+			Action:  model.ForwardActionNextHop,
+			NextHop: mustAddr(t, "192.0.2.2"),
+		},
+	}
+
+	matches := Lookup(rules, "r1", model.DefaultVRF, mustAddr(t, "10.0.1.42"))
+
+	assertEqual(t, matches, []model.ForwardingRule{
+		{
+			Node:      "r1",
+			VRF:       model.DefaultVRF,
+			Prefix:    mustPrefix(t, "10.0.1.0/24"),
+			Action:    model.ForwardActionInterface,
+			Interface: "Ethernet1",
+		},
+	})
+}
+
+func TestLookupReturnsECMPTies(t *testing.T) {
+	rules := Rules(
+		[]model.StaticRoute{
+			{
+				Node:    "r1",
+				VRF:     model.DefaultVRF,
+				Prefix:  mustPrefix(t, "10.0.0.0/24"),
+				Action:  model.StaticRouteActionNextHop,
+				NextHop: mustAddr(t, "192.0.2.2"),
+			},
+			{
+				Node:    "r1",
+				VRF:     model.DefaultVRF,
+				Prefix:  mustPrefix(t, "10.0.0.0/24"),
+				Action:  model.StaticRouteActionNextHop,
+				NextHop: mustAddr(t, "192.0.2.1"),
+			},
+		},
+		nil,
+	)
+
+	matches := Lookup(rules, "r1", model.DefaultVRF, mustAddr(t, "10.0.0.42"))
+
+	assertEqual(t, matches, []model.ForwardingRule{
+		{
+			Node:    "r1",
+			VRF:     model.DefaultVRF,
+			Prefix:  mustPrefix(t, "10.0.0.0/24"),
+			Action:  model.ForwardActionNextHop,
+			NextHop: mustAddr(t, "192.0.2.1"),
+		},
+		{
+			Node:    "r1",
+			VRF:     model.DefaultVRF,
+			Prefix:  mustPrefix(t, "10.0.0.0/24"),
+			Action:  model.ForwardActionNextHop,
+			NextHop: mustAddr(t, "192.0.2.2"),
+		},
+	})
+}
+
+func mustPrefix(t *testing.T, raw string) netip.Prefix {
+	t.Helper()
+
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		t.Fatalf("parse prefix %q: %v", raw, err)
+	}
+
+	return prefix.Masked()
+}
+
+func mustAddr(t *testing.T, raw string) netip.Addr {
+	t.Helper()
+
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		t.Fatalf("parse addr %q: %v", raw, err)
+	}
+
+	return addr
+}
+
+func assertEqual[T comparable](t *testing.T, got, want []T) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d items, want %d\ngot:  %#v\nwant: %#v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("item %d = %#v, want %#v\nall got:  %#v\nall want: %#v", i, got[i], want[i], got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add forwarding derivation for connected, static next-hop, and explicit drop routes
- add longest-prefix lookup with ECMP tie handling
- suppress connected routes for disabled interfaces in normalized snapshots

## Validation
- go test ./...
- golangci-lint run ./...

Closes #6