### PR TITLE
Build forwarding graph reachability checker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,9 @@ changes caused by network control-plane changes.
   implemented yet" when executed.
 - The paper PDF in the repository is reference material and should not be
   modified unless explicitly requested.
+- Before implementing or reviewing DNA behavior, read `docs/paper-notes.md`
+  for the project-specific summary of the paper, the source link, and the
+  current implementation scope.
 
 ## Planned Architecture
 

--- a/docs/paper-notes.md
+++ b/docs/paper-notes.md
@@ -1,0 +1,22 @@
+# Differential Network Analysis Paper Notes
+
+Reference paper:
+
+- Peng Zhang, Aaron Gember-Jacobson, Yueshang Zuo, Yuhao Huang, Xu Liu, and Hao Li.
+  "Differential Network Analysis." NSDI 2022.
+- USENIX page: https://www.usenix.org/conference/nsdi22/presentation/zhang-peng
+
+This repository implements a prototype inspired by the paper. The implementation
+is intentionally staged:
+
+1. Parse topology and normalized configuration inputs into internal facts.
+2. Derive forwarding rules from static and connected routes.
+3. Compute full reachability facts between edge ports.
+4. Later, compare old/new snapshots and add incremental traversal.
+
+The current MVP focuses on static and connected routes. It does not yet
+implement Batfish parsing, OSPF, BGP, ACL/header-space equivalence classes,
+waypointing, load balancing, or the paper's incremental change-point traversal.
+
+Do not commit a full `pdftotext` extraction of the paper into this repository.
+Use the USENIX open-access page above as the source of record.

--- a/internal/reachability/reachability.go
+++ b/internal/reachability/reachability.go
@@ -1,0 +1,312 @@
+package reachability
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+
+	"github.com/81ueman/dna/internal/forwarding"
+	"github.com/81ueman/dna/internal/model"
+	"github.com/81ueman/dna/internal/topology"
+)
+
+func Compute(topo topology.Topology, rules []model.ForwardingRule) ([]model.Reach, error) {
+	index, err := newIndex(topo, rules)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[model.Reach]bool{}
+	var reaches []model.Reach
+	for _, edge := range index.edgePorts {
+		for _, ec := range index.equivalenceClasses {
+			if edge.VRF != ec.vrf {
+				continue
+			}
+			index.traverse(edge, edge.Node, ec, map[visitKey]bool{}, seen, &reaches)
+		}
+	}
+
+	sortReaches(reaches)
+	return reaches, nil
+}
+
+type equivalenceClass struct {
+	vrf    model.VRF
+	prefix netip.Prefix
+}
+
+type graphIndex struct {
+	nodes              map[model.NodeID]bool
+	interfaces         map[interfaceKey]bool
+	linksByInterface   map[interfaceKey][]interfaceKey
+	edgePortsByIngress map[edgeKey][]model.EdgePort
+	edgePorts          []model.EdgePort
+	equivalenceClasses []equivalenceClass
+	rules              []model.ForwardingRule
+	interfaceRules     map[nodeVRF][]model.ForwardingRule
+}
+
+func newIndex(topo topology.Topology, rules []model.ForwardingRule) (*graphIndex, error) {
+	index := &graphIndex{
+		nodes:              map[model.NodeID]bool{},
+		interfaces:         map[interfaceKey]bool{},
+		linksByInterface:   map[interfaceKey][]interfaceKey{},
+		edgePortsByIngress: map[edgeKey][]model.EdgePort{},
+		interfaceRules:     map[nodeVRF][]model.ForwardingRule{},
+	}
+
+	for _, node := range topo.Nodes {
+		index.nodes[node.ID] = true
+	}
+	for _, iface := range topo.Interfaces {
+		index.interfaces[interfaceKey{node: iface.Node, iface: iface.ID}] = true
+	}
+	for _, link := range topo.Links {
+		from := interfaceKey{node: link.NodeA, iface: link.InterfaceA}
+		to := interfaceKey{node: link.NodeB, iface: link.InterfaceB}
+		if err := index.validateInterface(from, "link"); err != nil {
+			return nil, err
+		}
+		if err := index.validateInterface(to, "link"); err != nil {
+			return nil, err
+		}
+		index.linksByInterface[from] = append(index.linksByInterface[from], to)
+	}
+	for _, edge := range topo.EdgePorts {
+		if err := index.validateInterface(interfaceKey{node: edge.Node, iface: edge.Interface}, "edge port"); err != nil {
+			return nil, err
+		}
+		index.edgePorts = append(index.edgePorts, edge)
+		key := edgeKey{node: edge.Node, iface: edge.Interface, vrf: edge.VRF}
+		index.edgePortsByIngress[key] = append(index.edgePortsByIngress[key], edge)
+	}
+	sortEdgePorts(index.edgePorts)
+	for key := range index.edgePortsByIngress {
+		sortEdgePorts(index.edgePortsByIngress[key])
+	}
+	for key := range index.linksByInterface {
+		sortInterfaces(index.linksByInterface[key])
+	}
+
+	ecSeen := map[equivalenceClass]bool{}
+	ruleSeen := map[model.ForwardingRule]bool{}
+	for _, rule := range rules {
+		if !index.nodes[rule.Node] {
+			return nil, fmt.Errorf("forwarding rule references unknown node %q", rule.Node)
+		}
+		normalized := rule
+		normalized.Prefix = rule.Prefix.Masked()
+		if !ruleSeen[normalized] {
+			ruleSeen[normalized] = true
+			index.rules = append(index.rules, normalized)
+		}
+		ec := equivalenceClass{vrf: normalized.VRF, prefix: normalized.Prefix}
+		if !ecSeen[ec] {
+			ecSeen[ec] = true
+			index.equivalenceClasses = append(index.equivalenceClasses, ec)
+		}
+		if normalized.Action == model.ForwardActionInterface {
+			index.interfaceRules[nodeVRF{node: normalized.Node, vrf: normalized.VRF}] = append(
+				index.interfaceRules[nodeVRF{node: normalized.Node, vrf: normalized.VRF}],
+				normalized,
+			)
+		}
+	}
+	sortRules(index.rules)
+	sortECs(index.equivalenceClasses)
+	for key := range index.interfaceRules {
+		sortRules(index.interfaceRules[key])
+	}
+
+	return index, nil
+}
+
+func (i *graphIndex) validateInterface(key interfaceKey, context string) error {
+	if !i.nodes[key.node] {
+		return fmt.Errorf("%s references unknown node %q", context, key.node)
+	}
+	if !i.interfaces[key] {
+		return fmt.Errorf("%s references unknown interface %q on node %q", context, key.iface, key.node)
+	}
+	return nil
+}
+
+func (i *graphIndex) traverse(
+	source model.EdgePort,
+	node model.NodeID,
+	ec equivalenceClass,
+	visited map[visitKey]bool,
+	seen map[model.Reach]bool,
+	reaches *[]model.Reach,
+) {
+	key := visitKey{node: node, vrf: ec.vrf, prefix: ec.prefix}
+	if visited[key] {
+		return
+	}
+	visited[key] = true
+	defer delete(visited, key)
+
+	for _, rule := range forwarding.Lookup(i.rules, node, ec.vrf, ec.prefix.Addr()) {
+		switch rule.Action {
+		case model.ForwardActionDrop:
+			continue
+		case model.ForwardActionInterface:
+			i.exitInterface(source, rule.Node, rule.Interface, ec, visited, seen, reaches)
+		case model.ForwardActionNextHop:
+			for _, ifaceRule := range i.resolveNextHop(rule) {
+				i.exitInterface(source, ifaceRule.Node, ifaceRule.Interface, ec, visited, seen, reaches)
+			}
+		}
+	}
+}
+
+func (i *graphIndex) resolveNextHop(rule model.ForwardingRule) []model.ForwardingRule {
+	var matches []model.ForwardingRule
+	for _, ifaceRule := range i.interfaceRules[nodeVRF{node: rule.Node, vrf: rule.VRF}] {
+		if ifaceRule.Prefix.Contains(rule.NextHop) {
+			matches = append(matches, ifaceRule)
+		}
+	}
+	sortRules(matches)
+	return matches
+}
+
+func (i *graphIndex) exitInterface(
+	source model.EdgePort,
+	node model.NodeID,
+	iface model.InterfaceID,
+	ec equivalenceClass,
+	visited map[visitKey]bool,
+	seen map[model.Reach]bool,
+	reaches *[]model.Reach,
+) {
+	for _, dest := range i.edgePortsByIngress[edgeKey{node: node, iface: iface, vrf: ec.vrf}] {
+		if dest.ID == source.ID {
+			continue
+		}
+		reach := model.Reach{
+			Source: source.ID,
+			Dest:   dest.ID,
+			VRF:    ec.vrf,
+			Prefix: ec.prefix,
+		}
+		if !seen[reach] {
+			seen[reach] = true
+			*reaches = append(*reaches, reach)
+		}
+	}
+
+	for _, neighbor := range i.linksByInterface[interfaceKey{node: node, iface: iface}] {
+		i.traverse(source, neighbor.node, ec, visited, seen, reaches)
+	}
+}
+
+type interfaceKey struct {
+	node  model.NodeID
+	iface model.InterfaceID
+}
+
+type edgeKey struct {
+	node  model.NodeID
+	iface model.InterfaceID
+	vrf   model.VRF
+}
+
+type nodeVRF struct {
+	node model.NodeID
+	vrf  model.VRF
+}
+
+type visitKey struct {
+	node   model.NodeID
+	vrf    model.VRF
+	prefix netip.Prefix
+}
+
+func sortReaches(reaches []model.Reach) {
+	sort.Slice(reaches, func(i, j int) bool {
+		a, b := reaches[i], reaches[j]
+		if a.Source != b.Source {
+			return a.Source < b.Source
+		}
+		if a.Dest != b.Dest {
+			return a.Dest < b.Dest
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		return comparePrefix(a.Prefix, b.Prefix) < 0
+	})
+}
+
+func sortEdgePorts(edges []model.EdgePort) {
+	sort.Slice(edges, func(i, j int) bool {
+		a, b := edges[i], edges[j]
+		if a.ID != b.ID {
+			return a.ID < b.ID
+		}
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.Interface != b.Interface {
+			return a.Interface < b.Interface
+		}
+		return a.VRF < b.VRF
+	})
+}
+
+func sortInterfaces(interfaces []interfaceKey) {
+	sort.Slice(interfaces, func(i, j int) bool {
+		a, b := interfaces[i], interfaces[j]
+		if a.node != b.node {
+			return a.node < b.node
+		}
+		return a.iface < b.iface
+	})
+}
+
+func sortECs(ecs []equivalenceClass) {
+	sort.Slice(ecs, func(i, j int) bool {
+		a, b := ecs[i], ecs[j]
+		if a.vrf != b.vrf {
+			return a.vrf < b.vrf
+		}
+		return comparePrefix(a.prefix, b.prefix) < 0
+	})
+}
+
+func sortRules(rules []model.ForwardingRule) {
+	sort.Slice(rules, func(i, j int) bool {
+		a, b := rules[i], rules[j]
+		if a.Node != b.Node {
+			return a.Node < b.Node
+		}
+		if a.VRF != b.VRF {
+			return a.VRF < b.VRF
+		}
+		if comparePrefix(a.Prefix, b.Prefix) != 0 {
+			return comparePrefix(a.Prefix, b.Prefix) < 0
+		}
+		if a.Action != b.Action {
+			return a.Action < b.Action
+		}
+		if a.NextHop.Compare(b.NextHop) != 0 {
+			return a.NextHop.Compare(b.NextHop) < 0
+		}
+		return a.Interface < b.Interface
+	})
+}
+
+func comparePrefix(a, b netip.Prefix) int {
+	if cmp := a.Addr().Compare(b.Addr()); cmp != 0 {
+		return cmp
+	}
+	if a.Bits() < b.Bits() {
+		return -1
+	}
+	if a.Bits() > b.Bits() {
+		return 1
+	}
+	return 0
+}

--- a/internal/reachability/reachability.go
+++ b/internal/reachability/reachability.go
@@ -175,7 +175,6 @@ func (i *graphIndex) traverse(
 		return
 	}
 	visited[key] = true
-	defer delete(visited, key)
 
 	for _, rule := range forwarding.Lookup(i.rules, node, ec.vrf, ec.prefix.Addr()) {
 		switch rule.Action {

--- a/internal/reachability/reachability.go
+++ b/internal/reachability/reachability.go
@@ -44,7 +44,6 @@ type graphIndex struct {
 	edgePorts          []model.EdgePort
 	equivalenceClasses []equivalenceClass
 	rules              []model.ForwardingRule
-	interfaceRules     map[nodeVRF][]model.ForwardingRule
 }
 
 func newIndex(topo topology.Topology, rules []model.ForwardingRule) (*graphIndex, error) {
@@ -53,28 +52,31 @@ func newIndex(topo topology.Topology, rules []model.ForwardingRule) (*graphIndex
 		interfaces:         map[interfaceKey]bool{},
 		linksByInterface:   map[interfaceKey][]interfaceKey{},
 		edgePortsByIngress: map[edgeKey][]model.EdgePort{},
-		interfaceRules:     map[nodeVRF][]model.ForwardingRule{},
 	}
 
 	for _, node := range topo.Nodes {
 		index.nodes[node.ID] = true
 	}
 	for _, iface := range topo.Interfaces {
-		index.interfaces[interfaceKey{node: iface.Node, iface: iface.ID}] = true
+		index.interfaces[interfaceKey{node: iface.Node, iface: iface.ID, vrf: iface.VRF}] = true
 	}
 	for _, link := range topo.Links {
-		from := interfaceKey{node: link.NodeA, iface: link.InterfaceA}
-		to := interfaceKey{node: link.NodeB, iface: link.InterfaceB}
-		if err := index.validateInterface(from, "link"); err != nil {
+		fromNodeIface := nodeInterface{node: link.NodeA, iface: link.InterfaceA}
+		toNodeIface := nodeInterface{node: link.NodeB, iface: link.InterfaceB}
+		if err := index.validateLinkedInterface(fromNodeIface, "link"); err != nil {
 			return nil, err
 		}
-		if err := index.validateInterface(to, "link"); err != nil {
+		if err := index.validateLinkedInterface(toNodeIface, "link"); err != nil {
 			return nil, err
 		}
-		index.linksByInterface[from] = append(index.linksByInterface[from], to)
+		for _, vrf := range index.commonVRFs(fromNodeIface, toNodeIface) {
+			from := interfaceKey{node: link.NodeA, iface: link.InterfaceA, vrf: vrf}
+			to := interfaceKey{node: link.NodeB, iface: link.InterfaceB, vrf: vrf}
+			index.linksByInterface[from] = append(index.linksByInterface[from], to)
+		}
 	}
 	for _, edge := range topo.EdgePorts {
-		if err := index.validateInterface(interfaceKey{node: edge.Node, iface: edge.Interface}, "edge port"); err != nil {
+		if err := index.validateInterface(interfaceKey{node: edge.Node, iface: edge.Interface, vrf: edge.VRF}, "edge port"); err != nil {
 			return nil, err
 		}
 		index.edgePorts = append(index.edgePorts, edge)
@@ -89,8 +91,9 @@ func newIndex(topo topology.Topology, rules []model.ForwardingRule) (*graphIndex
 		sortInterfaces(index.linksByInterface[key])
 	}
 
-	ecSeen := map[equivalenceClass]bool{}
 	ruleSeen := map[model.ForwardingRule]bool{}
+	prefixesByVRF := map[model.VRF][]netip.Prefix{}
+	prefixSeen := map[equivalenceClass]bool{}
 	for _, rule := range rules {
 		if !index.nodes[rule.Node] {
 			return nil, fmt.Errorf("forwarding rule references unknown node %q", rule.Node)
@@ -101,23 +104,18 @@ func newIndex(topo topology.Topology, rules []model.ForwardingRule) (*graphIndex
 			ruleSeen[normalized] = true
 			index.rules = append(index.rules, normalized)
 		}
-		ec := equivalenceClass{vrf: normalized.VRF, prefix: normalized.Prefix}
-		if !ecSeen[ec] {
-			ecSeen[ec] = true
-			index.equivalenceClasses = append(index.equivalenceClasses, ec)
-		}
-		if normalized.Action == model.ForwardActionInterface {
-			index.interfaceRules[nodeVRF{node: normalized.Node, vrf: normalized.VRF}] = append(
-				index.interfaceRules[nodeVRF{node: normalized.Node, vrf: normalized.VRF}],
-				normalized,
-			)
+		prefixKey := equivalenceClass{vrf: normalized.VRF, prefix: normalized.Prefix}
+		if !prefixSeen[prefixKey] {
+			prefixSeen[prefixKey] = true
+			prefixesByVRF[normalized.VRF] = append(prefixesByVRF[normalized.VRF], normalized.Prefix)
 		}
 	}
 	sortRules(index.rules)
-	sortECs(index.equivalenceClasses)
-	for key := range index.interfaceRules {
-		sortRules(index.interfaceRules[key])
+	for vrf := range prefixesByVRF {
+		sortPrefixes(prefixesByVRF[vrf])
 	}
+	index.equivalenceClasses = buildEquivalenceClasses(prefixesByVRF)
+	sortECs(index.equivalenceClasses)
 
 	return index, nil
 }
@@ -127,9 +125,41 @@ func (i *graphIndex) validateInterface(key interfaceKey, context string) error {
 		return fmt.Errorf("%s references unknown node %q", context, key.node)
 	}
 	if !i.interfaces[key] {
-		return fmt.Errorf("%s references unknown interface %q on node %q", context, key.iface, key.node)
+		return fmt.Errorf("%s references unknown interface %q on node %q in VRF %q", context, key.iface, key.node, key.vrf)
 	}
 	return nil
+}
+
+func (i *graphIndex) validateLinkedInterface(key nodeInterface, context string) error {
+	if !i.nodes[key.node] {
+		return fmt.Errorf("%s references unknown node %q", context, key.node)
+	}
+	for iface := range i.interfaces {
+		if iface.node == key.node && iface.iface == key.iface {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s references unknown interface %q on node %q", context, key.iface, key.node)
+}
+
+func (i *graphIndex) commonVRFs(a, b nodeInterface) []model.VRF {
+	aVRFs := map[model.VRF]bool{}
+	for iface := range i.interfaces {
+		if iface.node == a.node && iface.iface == a.iface {
+			aVRFs[iface.vrf] = true
+		}
+	}
+
+	var vrfs []model.VRF
+	for iface := range i.interfaces {
+		if iface.node == b.node && iface.iface == b.iface && aVRFs[iface.vrf] {
+			vrfs = append(vrfs, iface.vrf)
+		}
+	}
+	sort.Slice(vrfs, func(i, j int) bool {
+		return vrfs[i] < vrfs[j]
+	})
+	return vrfs
 }
 
 func (i *graphIndex) traverse(
@@ -154,18 +184,44 @@ func (i *graphIndex) traverse(
 		case model.ForwardActionInterface:
 			i.exitInterface(source, rule.Node, rule.Interface, ec, visited, seen, reaches)
 		case model.ForwardActionNextHop:
-			for _, ifaceRule := range i.resolveNextHop(rule) {
+			for _, ifaceRule := range i.resolveNextHop(rule.Node, rule.VRF, rule.NextHop, map[nextHopVisit]bool{}) {
 				i.exitInterface(source, ifaceRule.Node, ifaceRule.Interface, ec, visited, seen, reaches)
 			}
 		}
 	}
 }
 
-func (i *graphIndex) resolveNextHop(rule model.ForwardingRule) []model.ForwardingRule {
+func (i *graphIndex) resolveNextHop(
+	node model.NodeID,
+	vrf model.VRF,
+	nextHop netip.Addr,
+	visited map[nextHopVisit]bool,
+) []model.ForwardingRule {
+	key := nextHopVisit{node: node, vrf: vrf, nextHop: nextHop}
+	if visited[key] {
+		return nil
+	}
+	visited[key] = true
+	defer delete(visited, key)
+
+	seen := map[model.ForwardingRule]bool{}
 	var matches []model.ForwardingRule
-	for _, ifaceRule := range i.interfaceRules[nodeVRF{node: rule.Node, vrf: rule.VRF}] {
-		if ifaceRule.Prefix.Contains(rule.NextHop) {
-			matches = append(matches, ifaceRule)
+	for _, rule := range forwarding.Lookup(i.rules, node, vrf, nextHop) {
+		switch rule.Action {
+		case model.ForwardActionDrop:
+			continue
+		case model.ForwardActionInterface:
+			if !seen[rule] {
+				seen[rule] = true
+				matches = append(matches, rule)
+			}
+		case model.ForwardActionNextHop:
+			for _, ifaceRule := range i.resolveNextHop(rule.Node, rule.VRF, rule.NextHop, visited) {
+				if !seen[ifaceRule] {
+					seen[ifaceRule] = true
+					matches = append(matches, ifaceRule)
+				}
+			}
 		}
 	}
 	sortRules(matches)
@@ -181,6 +237,10 @@ func (i *graphIndex) exitInterface(
 	seen map[model.Reach]bool,
 	reaches *[]model.Reach,
 ) {
+	if !i.interfaces[interfaceKey{node: node, iface: iface, vrf: ec.vrf}] {
+		return
+	}
+
 	for _, dest := range i.edgePortsByIngress[edgeKey{node: node, iface: iface, vrf: ec.vrf}] {
 		if dest.ID == source.ID {
 			continue
@@ -197,14 +257,20 @@ func (i *graphIndex) exitInterface(
 		}
 	}
 
-	for _, neighbor := range i.linksByInterface[interfaceKey{node: node, iface: iface}] {
+	for _, neighbor := range i.linksByInterface[interfaceKey{node: node, iface: iface, vrf: ec.vrf}] {
 		i.traverse(source, neighbor.node, ec, visited, seen, reaches)
 	}
+}
+
+type nodeInterface struct {
+	node  model.NodeID
+	iface model.InterfaceID
 }
 
 type interfaceKey struct {
 	node  model.NodeID
 	iface model.InterfaceID
+	vrf   model.VRF
 }
 
 type edgeKey struct {
@@ -213,15 +279,109 @@ type edgeKey struct {
 	vrf   model.VRF
 }
 
-type nodeVRF struct {
-	node model.NodeID
-	vrf  model.VRF
+type nextHopVisit struct {
+	node    model.NodeID
+	vrf     model.VRF
+	nextHop netip.Addr
 }
 
 type visitKey struct {
 	node   model.NodeID
 	vrf    model.VRF
 	prefix netip.Prefix
+}
+
+func buildEquivalenceClasses(prefixesByVRF map[model.VRF][]netip.Prefix) []equivalenceClass {
+	seen := map[equivalenceClass]bool{}
+	var ecs []equivalenceClass
+	for vrf, prefixes := range prefixesByVRF {
+		for _, prefix := range prefixes {
+			fragments := []netip.Prefix{prefix}
+			for _, other := range prefixes {
+				if !strictlyContainsPrefix(prefix, other) {
+					continue
+				}
+				var next []netip.Prefix
+				for _, fragment := range fragments {
+					next = append(next, subtractPrefix(fragment, other)...)
+				}
+				fragments = next
+			}
+			for _, fragment := range fragments {
+				ec := equivalenceClass{vrf: vrf, prefix: fragment}
+				if !seen[ec] {
+					seen[ec] = true
+					ecs = append(ecs, ec)
+				}
+			}
+		}
+	}
+	return ecs
+}
+
+func subtractPrefix(parent, child netip.Prefix) []netip.Prefix {
+	parent = parent.Masked()
+	child = child.Masked()
+	if !strictlyContainsPrefix(parent, child) {
+		return []netip.Prefix{parent}
+	}
+
+	var fragments []netip.Prefix
+	var carve func(netip.Prefix)
+	carve = func(current netip.Prefix) {
+		current = current.Masked()
+		if current == child {
+			return
+		}
+		if !containsPrefix(current, child) {
+			fragments = append(fragments, current)
+			return
+		}
+
+		left, right := splitPrefix(current)
+		if containsPrefix(left, child) {
+			fragments = append(fragments, right)
+			carve(left)
+			return
+		}
+		fragments = append(fragments, left)
+		carve(right)
+	}
+	carve(parent)
+	sortPrefixes(fragments)
+	return fragments
+}
+
+func strictlyContainsPrefix(parent, child netip.Prefix) bool {
+	return containsPrefix(parent, child) && parent.Bits() < child.Bits()
+}
+
+func containsPrefix(parent, child netip.Prefix) bool {
+	parent = parent.Masked()
+	child = child.Masked()
+	return parent.Addr().Is4() == child.Addr().Is4() &&
+		parent.Bits() <= child.Bits() &&
+		parent.Contains(child.Addr())
+}
+
+func splitPrefix(prefix netip.Prefix) (netip.Prefix, netip.Prefix) {
+	prefix = prefix.Masked()
+	nextBits := prefix.Bits() + 1
+	left := netip.PrefixFrom(prefix.Addr(), nextBits).Masked()
+	right := netip.PrefixFrom(setAddrBit(prefix.Addr(), prefix.Bits()), nextBits).Masked()
+	return left, right
+}
+
+func setAddrBit(addr netip.Addr, bit int) netip.Addr {
+	if addr.Is4() {
+		bytes := addr.As4()
+		bytes[bit/8] |= 1 << (7 - bit%8)
+		return netip.AddrFrom4(bytes)
+	}
+
+	bytes := addr.As16()
+	bytes[bit/8] |= 1 << (7 - bit%8)
+	return netip.AddrFrom16(bytes)
 }
 
 func sortReaches(reaches []model.Reach) {
@@ -262,7 +422,10 @@ func sortInterfaces(interfaces []interfaceKey) {
 		if a.node != b.node {
 			return a.node < b.node
 		}
-		return a.iface < b.iface
+		if a.iface != b.iface {
+			return a.iface < b.iface
+		}
+		return a.vrf < b.vrf
 	})
 }
 
@@ -273,6 +436,12 @@ func sortECs(ecs []equivalenceClass) {
 			return a.vrf < b.vrf
 		}
 		return comparePrefix(a.prefix, b.prefix) < 0
+	})
+}
+
+func sortPrefixes(prefixes []netip.Prefix) {
+	sort.Slice(prefixes, func(i, j int) bool {
+		return comparePrefix(prefixes[i], prefixes[j]) < 0
 	})
 }
 

--- a/internal/reachability/reachability.go
+++ b/internal/reachability/reachability.go
@@ -100,6 +100,14 @@ func newIndex(topo topology.Topology, rules []model.ForwardingRule) (*graphIndex
 		}
 		normalized := rule
 		normalized.Prefix = rule.Prefix.Masked()
+		if normalized.Action == model.ForwardActionInterface {
+			if err := index.validateInterface(
+				interfaceKey{node: normalized.Node, iface: normalized.Interface, vrf: normalized.VRF},
+				"forwarding rule",
+			); err != nil {
+				return nil, err
+			}
+		}
 		if !ruleSeen[normalized] {
 			ruleSeen[normalized] = true
 			index.rules = append(index.rules, normalized)

--- a/internal/reachability/reachability_test.go
+++ b/internal/reachability/reachability_test.go
@@ -1,0 +1,236 @@
+package reachability
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/81ueman/dna/internal/model"
+	"github.com/81ueman/dna/internal/topology"
+)
+
+func TestComputeStaticReachability(t *testing.T) {
+	reaches, err := Compute(
+		twoRouterTopology(model.DefaultVRF),
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.12.0/30", "r2-r1"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.2.0/24", "host"),
+			nextHopRule("r1", model.DefaultVRF, "10.0.2.0/24", "10.0.12.2"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.0/24")},
+	})
+}
+
+func TestComputeDropsUnreachablePrefixes(t *testing.T) {
+	reaches, err := Compute(
+		twoRouterTopology(model.DefaultVRF),
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.12.0/30", "r2-r1"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.2.0/24", "host"),
+			{
+				Node:   "r1",
+				VRF:    model.DefaultVRF,
+				Prefix: mustPrefix(t, "10.0.2.0/24"),
+				Action: model.ForwardActionDrop,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+	if len(reaches) != 0 {
+		t.Fatalf("reaches = %#v, want none", reaches)
+	}
+}
+
+func TestComputeLoopTerminates(t *testing.T) {
+	topo := topology.Topology{
+		Nodes: []model.Node{{ID: "r1"}, {ID: "r2"}},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "r1-r2", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "r2-r1", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "host1", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "host2", VRF: model.DefaultVRF},
+		},
+		Links: []model.Link{
+			{NodeA: "r1", InterfaceA: "r1-r2", NodeB: "r2", InterfaceB: "r2-r1"},
+			{NodeA: "r2", InterfaceA: "r2-r1", NodeB: "r1", InterfaceB: "r1-r2"},
+		},
+		EdgePorts: []model.EdgePort{
+			{ID: "h1", Node: "r1", Interface: "host1", VRF: model.DefaultVRF},
+			{ID: "h2", Node: "r2", Interface: "host2", VRF: model.DefaultVRF},
+		},
+	}
+
+	reaches, err := Compute(
+		topo,
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.12.0/30", "r2-r1"),
+			nextHopRule("r1", model.DefaultVRF, "10.0.9.0/24", "10.0.12.2"),
+			nextHopRule("r2", model.DefaultVRF, "10.0.9.0/24", "10.0.12.1"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+	if len(reaches) != 0 {
+		t.Fatalf("reaches = %#v, want none", reaches)
+	}
+}
+
+func TestComputeECMPReachesDestinationIfAnyPathWorks(t *testing.T) {
+	reaches, err := Compute(
+		twoRouterTopology(model.DefaultVRF),
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.12.0/30", "r2-r1"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.2.0/24", "host"),
+			nextHopRule("r1", model.DefaultVRF, "10.0.2.0/24", "10.0.12.2"),
+			nextHopRule("r1", model.DefaultVRF, "10.0.2.0/24", "192.0.2.1"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.0/24")},
+	})
+}
+
+func TestComputeHonorsVRFIsolation(t *testing.T) {
+	topo := twoRouterTopology("blue")
+	reaches, err := Compute(
+		topo,
+		[]model.ForwardingRule{
+			ifaceRule("r1", "blue", "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", "blue", "10.0.12.0/30", "r2-r1"),
+			ifaceRule("r2", "blue", "10.0.2.0/24", "host"),
+			nextHopRule("r1", "blue", "10.0.2.0/24", "10.0.12.2"),
+			ifaceRule("r1", model.DefaultVRF, "10.0.99.0/24", "host"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h2", VRF: "blue", Prefix: mustPrefix(t, "10.0.2.0/24")},
+	})
+}
+
+func TestComputeSortsReachFacts(t *testing.T) {
+	topo := topology.Topology{
+		Nodes: []model.Node{{ID: "r1"}},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "a", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "b", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "c", VRF: model.DefaultVRF},
+		},
+		EdgePorts: []model.EdgePort{
+			{ID: "z", Node: "r1", Interface: "a", VRF: model.DefaultVRF},
+			{ID: "a", Node: "r1", Interface: "b", VRF: model.DefaultVRF},
+			{ID: "m", Node: "r1", Interface: "c", VRF: model.DefaultVRF},
+		},
+	}
+
+	reaches, err := Compute(
+		topo,
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.2.0/24", "b"),
+			ifaceRule("r1", model.DefaultVRF, "10.0.3.0/24", "c"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "a", Dest: "m", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.3.0/24")},
+		{Source: "m", Dest: "a", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.0/24")},
+		{Source: "z", Dest: "a", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.0/24")},
+		{Source: "z", Dest: "m", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.3.0/24")},
+	})
+}
+
+func TestComputeRejectsInvalidTopologyReferences(t *testing.T) {
+	_, err := Compute(
+		topology.Topology{
+			Nodes:      []model.Node{{ID: "r1"}},
+			Interfaces: []model.Interface{{Node: "r1", ID: "eth1", VRF: model.DefaultVRF}},
+			Links: []model.Link{
+				{NodeA: "r1", InterfaceA: "eth1", NodeB: "r2", InterfaceB: "eth1"},
+			},
+		},
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("Compute succeeded, want invalid topology error")
+	}
+}
+
+func twoRouterTopology(vrf model.VRF) topology.Topology {
+	return topology.Topology{
+		Nodes: []model.Node{{ID: "r1"}, {ID: "r2"}},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "r1-r2", VRF: vrf},
+			{Node: "r1", ID: "host", VRF: vrf},
+			{Node: "r2", ID: "r2-r1", VRF: vrf},
+			{Node: "r2", ID: "host", VRF: vrf},
+		},
+		Links: []model.Link{
+			{NodeA: "r1", InterfaceA: "r1-r2", NodeB: "r2", InterfaceB: "r2-r1"},
+			{NodeA: "r2", InterfaceA: "r2-r1", NodeB: "r1", InterfaceB: "r1-r2"},
+		},
+		EdgePorts: []model.EdgePort{
+			{ID: "h1", Node: "r1", Interface: "host", VRF: vrf},
+			{ID: "h2", Node: "r2", Interface: "host", VRF: vrf},
+		},
+	}
+}
+
+func ifaceRule(node model.NodeID, vrf model.VRF, prefix string, iface model.InterfaceID) model.ForwardingRule {
+	return model.ForwardingRule{
+		Node:      node,
+		VRF:       vrf,
+		Prefix:    netip.MustParsePrefix(prefix).Masked(),
+		Action:    model.ForwardActionInterface,
+		Interface: iface,
+	}
+}
+
+func nextHopRule(node model.NodeID, vrf model.VRF, prefix, nextHop string) model.ForwardingRule {
+	return model.ForwardingRule{
+		Node:    node,
+		VRF:     vrf,
+		Prefix:  netip.MustParsePrefix(prefix).Masked(),
+		Action:  model.ForwardActionNextHop,
+		NextHop: netip.MustParseAddr(nextHop),
+	}
+}
+
+func mustPrefix(t *testing.T, raw string) netip.Prefix {
+	t.Helper()
+	return netip.MustParsePrefix(raw).Masked()
+}
+
+func assertEqual[T comparable](t *testing.T, got, want []T) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d items, want %d\ngot:  %#v\nwant: %#v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("item %d = %#v, want %#v\nall got:  %#v\nall want: %#v", i, got[i], want[i], got, want)
+		}
+	}
+}

--- a/internal/reachability/reachability_test.go
+++ b/internal/reachability/reachability_test.go
@@ -227,6 +227,7 @@ func TestComputeECMPReachesDestinationIfAnyPathWorks(t *testing.T) {
 
 func TestComputeHonorsVRFIsolation(t *testing.T) {
 	topo := twoRouterTopology("blue")
+	topo.Interfaces = append(topo.Interfaces, model.Interface{Node: "r1", ID: "host", VRF: model.DefaultVRF})
 	reaches, err := Compute(
 		topo,
 		[]model.ForwardingRule{
@@ -362,6 +363,36 @@ func TestComputeRejectsInvalidTopologyReferences(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatalf("Compute succeeded, want invalid topology error")
+	}
+}
+
+func TestComputeRejectsInterfaceRuleWithUnknownInterface(t *testing.T) {
+	_, err := Compute(
+		topology.Topology{
+			Nodes:      []model.Node{{ID: "r1"}},
+			Interfaces: []model.Interface{{Node: "r1", ID: "eth1", VRF: model.DefaultVRF}},
+		},
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.2.0/24", "eth2"),
+		},
+	)
+	if err == nil {
+		t.Fatalf("Compute succeeded, want unknown interface rule error")
+	}
+}
+
+func TestComputeRejectsInterfaceRuleWithWrongVRF(t *testing.T) {
+	_, err := Compute(
+		topology.Topology{
+			Nodes:      []model.Node{{ID: "r1"}},
+			Interfaces: []model.Interface{{Node: "r1", ID: "eth1", VRF: model.DefaultVRF}},
+		},
+		[]model.ForwardingRule{
+			ifaceRule("r1", "blue", "10.0.2.0/24", "eth1"),
+		},
+	)
+	if err == nil {
+		t.Fatalf("Compute succeeded, want wrong VRF interface rule error")
 	}
 }
 

--- a/internal/reachability/reachability_test.go
+++ b/internal/reachability/reachability_test.go
@@ -149,6 +149,62 @@ func TestComputeLoopTerminates(t *testing.T) {
 	}
 }
 
+func TestComputeVisitsEachStateOnceAcrossECMPAndCycles(t *testing.T) {
+	topo := topology.Topology{
+		Nodes: []model.Node{{ID: "r1"}, {ID: "r2"}, {ID: "r3"}, {ID: "r4"}},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "host", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "r1-r2", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "r1-r3", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "r2-r1", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "r2-r3", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "r2-r4", VRF: model.DefaultVRF},
+			{Node: "r3", ID: "r3-r1", VRF: model.DefaultVRF},
+			{Node: "r3", ID: "r3-r2", VRF: model.DefaultVRF},
+			{Node: "r3", ID: "r3-r4", VRF: model.DefaultVRF},
+			{Node: "r4", ID: "r4-r2", VRF: model.DefaultVRF},
+			{Node: "r4", ID: "r4-r3", VRF: model.DefaultVRF},
+			{Node: "r4", ID: "host", VRF: model.DefaultVRF},
+		},
+		Links: []model.Link{
+			{NodeA: "r1", InterfaceA: "r1-r2", NodeB: "r2", InterfaceB: "r2-r1"},
+			{NodeA: "r2", InterfaceA: "r2-r1", NodeB: "r1", InterfaceB: "r1-r2"},
+			{NodeA: "r1", InterfaceA: "r1-r3", NodeB: "r3", InterfaceB: "r3-r1"},
+			{NodeA: "r3", InterfaceA: "r3-r1", NodeB: "r1", InterfaceB: "r1-r3"},
+			{NodeA: "r2", InterfaceA: "r2-r3", NodeB: "r3", InterfaceB: "r3-r2"},
+			{NodeA: "r3", InterfaceA: "r3-r2", NodeB: "r2", InterfaceB: "r2-r3"},
+			{NodeA: "r2", InterfaceA: "r2-r4", NodeB: "r4", InterfaceB: "r4-r2"},
+			{NodeA: "r4", InterfaceA: "r4-r2", NodeB: "r2", InterfaceB: "r2-r4"},
+			{NodeA: "r3", InterfaceA: "r3-r4", NodeB: "r4", InterfaceB: "r4-r3"},
+			{NodeA: "r4", InterfaceA: "r4-r3", NodeB: "r3", InterfaceB: "r3-r4"},
+		},
+		EdgePorts: []model.EdgePort{
+			{ID: "h1", Node: "r1", Interface: "host", VRF: model.DefaultVRF},
+			{ID: "h4", Node: "r4", Interface: "host", VRF: model.DefaultVRF},
+		},
+	}
+
+	reaches, err := Compute(
+		topo,
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.4.0/24", "r1-r2"),
+			ifaceRule("r1", model.DefaultVRF, "10.0.4.0/24", "r1-r3"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.4.0/24", "r2-r3"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.4.0/24", "r2-r4"),
+			ifaceRule("r3", model.DefaultVRF, "10.0.4.0/24", "r3-r2"),
+			ifaceRule("r3", model.DefaultVRF, "10.0.4.0/24", "r3-r4"),
+			ifaceRule("r4", model.DefaultVRF, "10.0.4.0/24", "host"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h4", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.4.0/24")},
+	})
+}
+
 func TestComputeECMPReachesDestinationIfAnyPathWorks(t *testing.T) {
 	reaches, err := Compute(
 		twoRouterTopology(model.DefaultVRF),

--- a/internal/reachability/reachability_test.go
+++ b/internal/reachability/reachability_test.go
@@ -50,6 +50,69 @@ func TestComputeDropsUnreachablePrefixes(t *testing.T) {
 	}
 }
 
+func TestComputeSplitsOverlappingPrefixes(t *testing.T) {
+	reaches, err := Compute(
+		twoRouterTopology(model.DefaultVRF),
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.12.0/30", "r2-r1"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.0.0/22", "host"),
+			nextHopRule("r1", model.DefaultVRF, "10.0.0.0/22", "10.0.12.2"),
+			{
+				Node:   "r1",
+				VRF:    model.DefaultVRF,
+				Prefix: mustPrefix(t, "10.0.2.0/24"),
+				Action: model.ForwardActionDrop,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.0.0/23")},
+		{Source: "h1", Dest: "h2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.3.0/24")},
+	})
+}
+
+func TestComputeResolvesRecursiveStaticNextHop(t *testing.T) {
+	reaches, err := Compute(
+		twoRouterTopology(model.DefaultVRF),
+		[]model.ForwardingRule{
+			ifaceRule("r1", model.DefaultVRF, "10.0.12.0/30", "r1-r2"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.12.0/30", "r2-r1"),
+			ifaceRule("r2", model.DefaultVRF, "10.0.2.0/24", "host"),
+			nextHopRule("r1", model.DefaultVRF, "192.0.2.0/24", "10.0.12.2"),
+			nextHopRule("r1", model.DefaultVRF, "10.0.2.0/24", "192.0.2.2"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h2", VRF: model.DefaultVRF, Prefix: mustPrefix(t, "10.0.2.0/24")},
+	})
+}
+
+func TestComputeRecursiveNextHopLoopTerminates(t *testing.T) {
+	reaches, err := Compute(
+		twoRouterTopology(model.DefaultVRF),
+		[]model.ForwardingRule{
+			nextHopRule("r1", model.DefaultVRF, "10.0.2.0/24", "192.0.2.2"),
+			nextHopRule("r1", model.DefaultVRF, "192.0.2.0/24", "198.51.100.2"),
+			nextHopRule("r1", model.DefaultVRF, "198.51.100.0/24", "192.0.2.2"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+	if len(reaches) != 0 {
+		t.Fatalf("reaches = %#v, want none", reaches)
+	}
+}
+
 func TestComputeLoopTerminates(t *testing.T) {
 	topo := topology.Topology{
 		Nodes: []model.Node{{ID: "r1"}, {ID: "r2"}},
@@ -116,6 +179,75 @@ func TestComputeHonorsVRFIsolation(t *testing.T) {
 			ifaceRule("r2", "blue", "10.0.2.0/24", "host"),
 			nextHopRule("r1", "blue", "10.0.2.0/24", "10.0.12.2"),
 			ifaceRule("r1", model.DefaultVRF, "10.0.99.0/24", "host"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	assertEqual(t, reaches, []model.Reach{
+		{Source: "h1", Dest: "h2", VRF: "blue", Prefix: mustPrefix(t, "10.0.2.0/24")},
+	})
+}
+
+func TestComputeDoesNotTraverseLinkAcrossDifferentInterfaceVRFs(t *testing.T) {
+	topo := topology.Topology{
+		Nodes: []model.Node{{ID: "r1"}, {ID: "r2"}},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "r1-r2", VRF: "blue"},
+			{Node: "r1", ID: "host", VRF: "blue"},
+			{Node: "r2", ID: "r2-r1", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "host", VRF: "blue"},
+		},
+		Links: []model.Link{
+			{NodeA: "r1", InterfaceA: "r1-r2", NodeB: "r2", InterfaceB: "r2-r1"},
+		},
+		EdgePorts: []model.EdgePort{
+			{ID: "h1", Node: "r1", Interface: "host", VRF: "blue"},
+			{ID: "h2", Node: "r2", Interface: "host", VRF: "blue"},
+		},
+	}
+
+	reaches, err := Compute(
+		topo,
+		[]model.ForwardingRule{
+			ifaceRule("r1", "blue", "10.0.2.0/24", "r1-r2"),
+			ifaceRule("r2", "blue", "10.0.2.0/24", "host"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+	if len(reaches) != 0 {
+		t.Fatalf("reaches = %#v, want none", reaches)
+	}
+}
+
+func TestComputeTraversesLinkOnlyWithinMatchingInterfaceVRF(t *testing.T) {
+	topo := topology.Topology{
+		Nodes: []model.Node{{ID: "r1"}, {ID: "r2"}},
+		Interfaces: []model.Interface{
+			{Node: "r1", ID: "r1-r2", VRF: model.DefaultVRF},
+			{Node: "r1", ID: "r1-r2", VRF: "blue"},
+			{Node: "r1", ID: "host", VRF: "blue"},
+			{Node: "r2", ID: "r2-r1", VRF: model.DefaultVRF},
+			{Node: "r2", ID: "r2-r1", VRF: "blue"},
+			{Node: "r2", ID: "host", VRF: "blue"},
+		},
+		Links: []model.Link{
+			{NodeA: "r1", InterfaceA: "r1-r2", NodeB: "r2", InterfaceB: "r2-r1"},
+		},
+		EdgePorts: []model.EdgePort{
+			{ID: "h1", Node: "r1", Interface: "host", VRF: "blue"},
+			{ID: "h2", Node: "r2", Interface: "host", VRF: "blue"},
+		},
+	}
+
+	reaches, err := Compute(
+		topo,
+		[]model.ForwardingRule{
+			ifaceRule("r1", "blue", "10.0.2.0/24", "r1-r2"),
+			ifaceRule("r2", "blue", "10.0.2.0/24", "host"),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add the reachability checker for forwarding rules and topology edge ports
- split overlapping prefixes into disjoint reachability ECs
- resolve recursive static next hops and keep traversal VRF-aware
- reject malformed interface forwarding rules

## Tests
- go test ./...
- golangci-lint run ./...

Closes #9