### PR TITLE
Add reachability diff output primitives

### DIFF
--- a/internal/reachability/diff.go
+++ b/internal/reachability/diff.go
@@ -1,0 +1,79 @@
+package reachability
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/81ueman/dna/internal/model"
+)
+
+type ChangeKind string
+
+const (
+	ChangeAdd    ChangeKind = "+"
+	ChangeRemove ChangeKind = "-"
+)
+
+type Change struct {
+	Kind  ChangeKind
+	Reach model.Reach
+}
+
+func Diff(oldReaches, newReaches []model.Reach) []Change {
+	oldSet := reachSet(oldReaches)
+	newSet := reachSet(newReaches)
+
+	var changes []Change
+	for reach := range newSet {
+		if !oldSet[reach] {
+			changes = append(changes, Change{Kind: ChangeAdd, Reach: reach})
+		}
+	}
+	for reach := range oldSet {
+		if !newSet[reach] {
+			changes = append(changes, Change{Kind: ChangeRemove, Reach: reach})
+		}
+	}
+
+	sortChanges(changes)
+	return changes
+}
+
+func FormatChange(change Change) string {
+	return fmt.Sprintf(
+		"%sReach(%s,%s,%s,%s)",
+		change.Kind,
+		change.Reach.Source,
+		change.Reach.Dest,
+		change.Reach.VRF,
+		change.Reach.Prefix.Masked(),
+	)
+}
+
+func reachSet(reaches []model.Reach) map[model.Reach]bool {
+	set := make(map[model.Reach]bool, len(reaches))
+	for _, reach := range reaches {
+		reach.Prefix = reach.Prefix.Masked()
+		set[reach] = true
+	}
+	return set
+}
+
+func sortChanges(changes []Change) {
+	sort.Slice(changes, func(i, j int) bool {
+		a, b := changes[i], changes[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Reach.Source != b.Reach.Source {
+			return a.Reach.Source < b.Reach.Source
+		}
+		if a.Reach.Dest != b.Reach.Dest {
+			return a.Reach.Dest < b.Reach.Dest
+		}
+		if a.Reach.VRF != b.Reach.VRF {
+			return a.Reach.VRF < b.Reach.VRF
+		}
+		return comparePrefix(a.Reach.Prefix, b.Reach.Prefix) < 0
+	})
+}

--- a/internal/reachability/diff_test.go
+++ b/internal/reachability/diff_test.go
@@ -1,0 +1,105 @@
+package reachability
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/81ueman/dna/internal/model"
+)
+
+func TestDiffReturnsAddedReachability(t *testing.T) {
+	changes := Diff(nil, []model.Reach{
+		reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24"),
+	})
+
+	assertEqual(t, changes, []Change{
+		{Kind: ChangeAdd, Reach: reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24")},
+	})
+}
+
+func TestDiffReturnsRemovedReachability(t *testing.T) {
+	changes := Diff(
+		[]model.Reach{
+			reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24"),
+		},
+		nil,
+	)
+
+	assertEqual(t, changes, []Change{
+		{Kind: ChangeRemove, Reach: reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24")},
+	})
+}
+
+func TestDiffSuppressesUnchangedReachability(t *testing.T) {
+	oldReaches := []model.Reach{
+		reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24"),
+	}
+	newReaches := []model.Reach{
+		reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24"),
+	}
+
+	changes := Diff(oldReaches, newReaches)
+
+	if len(changes) != 0 {
+		t.Fatalf("changes = %#v, want none", changes)
+	}
+}
+
+func TestDiffSortsMixedChanges(t *testing.T) {
+	changes := Diff(
+		[]model.Reach{
+			reach("z", "a", model.DefaultVRF, "10.0.4.0/24"),
+			reach("a", "z", "blue", "10.0.1.0/24"),
+		},
+		[]model.Reach{
+			reach("a", "m", model.DefaultVRF, "10.0.3.0/24"),
+			reach("a", "m", model.DefaultVRF, "10.0.2.0/24"),
+		},
+	)
+
+	assertEqual(t, changes, []Change{
+		{Kind: ChangeAdd, Reach: reach("a", "m", model.DefaultVRF, "10.0.2.0/24")},
+		{Kind: ChangeAdd, Reach: reach("a", "m", model.DefaultVRF, "10.0.3.0/24")},
+		{Kind: ChangeRemove, Reach: reach("a", "z", "blue", "10.0.1.0/24")},
+		{Kind: ChangeRemove, Reach: reach("z", "a", model.DefaultVRF, "10.0.4.0/24")},
+	})
+}
+
+func TestDiffDeduplicatesAndMasksInput(t *testing.T) {
+	oldReaches := []model.Reach{
+		reach("h1", "h2", model.DefaultVRF, "10.0.2.42/24"),
+		reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24"),
+	}
+	newReaches := []model.Reach{
+		reach("h1", "h2", model.DefaultVRF, "10.0.3.42/24"),
+		reach("h1", "h2", model.DefaultVRF, "10.0.3.0/24"),
+	}
+
+	changes := Diff(oldReaches, newReaches)
+
+	assertEqual(t, changes, []Change{
+		{Kind: ChangeAdd, Reach: reach("h1", "h2", model.DefaultVRF, "10.0.3.0/24")},
+		{Kind: ChangeRemove, Reach: reach("h1", "h2", model.DefaultVRF, "10.0.2.0/24")},
+	})
+}
+
+func TestFormatChange(t *testing.T) {
+	got := FormatChange(Change{
+		Kind:  ChangeAdd,
+		Reach: reach("h1", "h2", model.DefaultVRF, "10.0.2.42/24"),
+	})
+
+	const want = "+Reach(h1,h2,default,10.0.2.0/24)"
+	if got != want {
+		t.Fatalf("FormatChange = %q, want %q", got, want)
+	}
+}
+
+func reach(source, dest model.EdgePortID, vrf model.VRF, prefix string) model.Reach {
+	return model.Reach{
+		Source: source,
+		Dest:   dest,
+		VRF:    vrf,
+		Prefix: netip.MustParsePrefix(prefix).Masked(),
+	}
+}


### PR DESCRIPTION
## Summary
- add reachability change primitives for added and removed Reach facts
- add deterministic reachability diffing with prefix masking and deduplication
- add formatter output for future CLI use

Closes #8

## Tests
- go test ./...