### PR TITLE
Wire dna diff CLI for static snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 the NSDI 2022 paper by Zhang et al.
 
 The project goal is to report forwarding-behavior changes caused by network
-control-plane changes. The first milestone is only the Go CLI scaffold. Routing
-models, topology loading, Batfish parsing, reachability checking, and
-incremental analysis are planned for later milestones.
+control-plane changes. The current MVP supports Containerlab topology files,
+normalized YAML configuration snapshots, static and connected routes, full
+reachability computation, and reachability diff output.
 
 ## Design Direction
 
@@ -31,10 +31,28 @@ The planned first operator workflow is:
 dna diff \
   --topology topology.clab.yaml \
   --old-configs configs/old \
-  --new-configs configs/new
+  --new-configs configs/new \
+  --parser-backend normalized
 ```
 
-At this stage, `dna diff` is intentionally not implemented.
+Run the included static-route example:
+
+```sh
+go run ./cmd/dna diff \
+  --topology examples/static/topology.clab.yaml \
+  --old-configs examples/static/configs/old \
+  --new-configs examples/static/configs/new
+```
+
+Expected output:
+
+```text
++Reach(h1,h2,default,10.0.2.0/24)
+```
+
+The `normalized` parser backend is implemented. The `batfish` backend flag is
+reserved for the Batfish parser adapter milestone and currently returns a clear
+not-implemented error.
 
 ## Development
 

--- a/examples/static/configs/new/r1.yaml
+++ b/examples/static/configs/new/r1.yaml
@@ -1,0 +1,11 @@
+node: r1
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.1/30
+  eth2:
+    addresses:
+      - 10.0.1.1/24
+static_routes:
+  - prefix: 10.0.2.0/24
+    next_hop: 10.0.12.2

--- a/examples/static/configs/new/r2.yaml
+++ b/examples/static/configs/new/r2.yaml
@@ -1,0 +1,8 @@
+node: r2
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.2/30
+  eth2:
+    addresses:
+      - 10.0.2.1/24

--- a/examples/static/configs/old/r1.yaml
+++ b/examples/static/configs/old/r1.yaml
@@ -1,0 +1,8 @@
+node: r1
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.1/30
+  eth2:
+    addresses:
+      - 10.0.1.1/24

--- a/examples/static/configs/old/r2.yaml
+++ b/examples/static/configs/old/r2.yaml
@@ -1,0 +1,8 @@
+node: r2
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.2/30
+  eth2:
+    addresses:
+      - 10.0.2.1/24

--- a/examples/static/topology.clab.yaml
+++ b/examples/static/topology.clab.yaml
@@ -1,0 +1,15 @@
+name: static
+topology:
+  nodes:
+    r1: {}
+    r2: {}
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+x-dna:
+  edge_ports:
+    - name: h1
+      node: r1
+      interface: eth2
+    - name: h2
+      node: r2
+      interface: eth2

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,6 +3,11 @@ package cli
 import (
 	"fmt"
 
+	"github.com/81ueman/dna/internal/config"
+	"github.com/81ueman/dna/internal/forwarding"
+	"github.com/81ueman/dna/internal/model"
+	"github.com/81ueman/dna/internal/reachability"
+	"github.com/81ueman/dna/internal/topology"
 	"github.com/spf13/cobra"
 )
 
@@ -28,25 +33,90 @@ func newDiffCommand() *cobra.Command {
 		Use:   "diff",
 		Short: "Compare old and new network snapshots",
 		Long: "Compare old and new network snapshots and report differential " +
-			"reachability facts. This scaffold only defines the command shape.",
+			"reachability facts.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiff(opts)
+			return runDiff(cmd, opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&opts.topology, "topology", "", "path to a Containerlab topology file")
 	cmd.Flags().StringVar(&opts.oldConfigs, "old-configs", "", "path to the old configuration snapshot directory")
 	cmd.Flags().StringVar(&opts.newConfigs, "new-configs", "", "path to the new configuration snapshot directory")
+	cmd.Flags().StringVar(&opts.parserBackend, "parser-backend", "normalized", "configuration parser backend: normalized or batfish")
 
 	return cmd
 }
 
 type diffOptions struct {
-	topology   string
-	oldConfigs string
-	newConfigs string
+	topology      string
+	oldConfigs    string
+	newConfigs    string
+	parserBackend string
 }
 
-func runDiff(opts diffOptions) error {
-	return fmt.Errorf("dna diff is not implemented yet")
+func runDiff(cmd *cobra.Command, opts diffOptions) error {
+	if err := validateDiffOptions(opts); err != nil {
+		return err
+	}
+	if opts.parserBackend == "batfish" {
+		return fmt.Errorf("parser backend %q is not implemented yet", opts.parserBackend)
+	}
+
+	topo, err := topology.LoadContainerlab(opts.topology, topology.LoadOptions{})
+	if err != nil {
+		return fmt.Errorf("load topology: %w", err)
+	}
+
+	oldReaches, err := computeSnapshotReachability(opts.oldConfigs, topo)
+	if err != nil {
+		return fmt.Errorf("compute old reachability: %w", err)
+	}
+	newReaches, err := computeSnapshotReachability(opts.newConfigs, topo)
+	if err != nil {
+		return fmt.Errorf("compute new reachability: %w", err)
+	}
+
+	changes := reachability.Diff(oldReaches, newReaches)
+	out := cmd.OutOrStdout()
+	if len(changes) == 0 {
+		_, err = fmt.Fprintln(out, "No reachability changes.")
+		return err
+	}
+	for _, change := range changes {
+		if _, err := fmt.Fprintln(out, reachability.FormatChange(change)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDiffOptions(opts diffOptions) error {
+	if opts.topology == "" {
+		return fmt.Errorf("--topology is required")
+	}
+	if opts.oldConfigs == "" {
+		return fmt.Errorf("--old-configs is required")
+	}
+	if opts.newConfigs == "" {
+		return fmt.Errorf("--new-configs is required")
+	}
+	switch opts.parserBackend {
+	case "normalized", "batfish":
+		return nil
+	default:
+		return fmt.Errorf("unsupported parser backend %q", opts.parserBackend)
+	}
+}
+
+func computeSnapshotReachability(path string, topo topology.Topology) ([]model.Reach, error) {
+	snapshot, err := config.LoadSnapshotDir(path, topo)
+	if err != nil {
+		return nil, fmt.Errorf("load configs: %w", err)
+	}
+	rules := forwarding.Rules(snapshot.StaticRoutes, snapshot.ConnectedRoutes)
+	reaches, err := reachability.Compute(topo, rules)
+	if err != nil {
+		return nil, err
+	}
+	return reaches, nil
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -38,9 +40,190 @@ func TestDiffHelp(t *testing.T) {
 	}
 
 	got := out.String()
-	for _, want := range []string{"--topology", "--old-configs", "--new-configs"} {
+	for _, want := range []string{"--topology", "--old-configs", "--new-configs", "--parser-backend"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("diff help does not mention %s; got:\n%s", want, got)
 		}
+	}
+}
+
+func TestDiffCommandReportsReachabilityChanges(t *testing.T) {
+	fixture := writeStaticFixture(t)
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"diff",
+		"--topology", fixture.topology,
+		"--old-configs", fixture.oldConfigs,
+		"--new-configs", fixture.newConfigs,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diff returned error: %v\noutput:\n%s", err, out.String())
+	}
+
+	const want = "+Reach(h1,h2,default,10.0.2.0/24)\n"
+	if got := out.String(); got != want {
+		t.Fatalf("diff output = %q, want %q", got, want)
+	}
+}
+
+func TestDiffCommandReportsNoReachabilityChanges(t *testing.T) {
+	fixture := writeStaticFixture(t)
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"diff",
+		"--topology", fixture.topology,
+		"--old-configs", fixture.oldConfigs,
+		"--new-configs", fixture.oldConfigs,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diff returned error: %v\noutput:\n%s", err, out.String())
+	}
+
+	const want = "No reachability changes.\n"
+	if got := out.String(); got != want {
+		t.Fatalf("diff output = %q, want %q", got, want)
+	}
+}
+
+func TestDiffCommandValidatesRequiredFlags(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"diff"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("diff succeeded, want required flag error")
+	}
+	if !strings.Contains(err.Error(), "--topology is required") {
+		t.Fatalf("error = %q, want missing topology", err)
+	}
+}
+
+func TestDiffCommandRejectsUnimplementedBatfishBackend(t *testing.T) {
+	fixture := writeStaticFixture(t)
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"diff",
+		"--topology", fixture.topology,
+		"--old-configs", fixture.oldConfigs,
+		"--new-configs", fixture.newConfigs,
+		"--parser-backend", "batfish",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("diff succeeded, want batfish error")
+	}
+	if !strings.Contains(err.Error(), `parser backend "batfish" is not implemented yet`) {
+		t.Fatalf("error = %q, want batfish not implemented", err)
+	}
+}
+
+type staticFixture struct {
+	topology   string
+	oldConfigs string
+	newConfigs string
+}
+
+func writeStaticFixture(t *testing.T) staticFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, "topology.clab.yaml")
+	oldDir := filepath.Join(dir, "old")
+	newDir := filepath.Join(dir, "new")
+	if err := os.MkdirAll(oldDir, 0o755); err != nil {
+		t.Fatalf("create old dir: %v", err)
+	}
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatalf("create new dir: %v", err)
+	}
+
+	writeFile(t, topologyPath, `
+name: static
+topology:
+  nodes:
+    r1: {}
+    r2: {}
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+x-dna:
+  edge_ports:
+    - name: h1
+      node: r1
+      interface: eth2
+    - name: h2
+      node: r2
+      interface: eth2
+`)
+	writeFile(t, filepath.Join(oldDir, "r1.yaml"), `
+node: r1
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.1/30
+  eth2:
+    addresses:
+      - 10.0.1.1/24
+`)
+	writeFile(t, filepath.Join(oldDir, "r2.yaml"), `
+node: r2
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.2/30
+  eth2:
+    addresses:
+      - 10.0.2.1/24
+`)
+	writeFile(t, filepath.Join(newDir, "r1.yaml"), `
+node: r1
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.1/30
+  eth2:
+    addresses:
+      - 10.0.1.1/24
+static_routes:
+  - prefix: 10.0.2.0/24
+    next_hop: 10.0.12.2
+`)
+	writeFile(t, filepath.Join(newDir, "r2.yaml"), `
+node: r2
+interfaces:
+  eth1:
+    addresses:
+      - 10.0.12.2/30
+  eth2:
+    addresses:
+      - 10.0.2.1/24
+`)
+
+	return staticFixture{
+		topology:   topologyPath,
+		oldConfigs: oldDir,
+		newConfigs: newDir,
+	}
+}
+
+func writeFile(t *testing.T, path, data string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
## Summary
- wire dna diff to load Containerlab topology and normalized old/new snapshots
- derive forwarding rules, compute reachability, and print stable Reach diff output
- add a static-route example fixture and README instructions

Closes #10

## Tests
- go test ./...
- go run ./cmd/dna diff --topology examples/static/topology.clab.yaml --old-configs examples/static/configs/old --new-configs examples/static/configs/new